### PR TITLE
feat(simulator): add interactive LUI simulator (issue #8)

### DIFF
--- a/examples/task_manager_schema.json
+++ b/examples/task_manager_schema.json
@@ -1,0 +1,146 @@
+{
+  "schema_id": "task-manager-v1",
+  "name": "Task Manager LUI",
+  "description": "A Language User Interface for managing tasks and projects",
+  "version": "1.0.0",
+  "domain": {
+    "domain_name": "task-management",
+    "subdomain": "personal-productivity",
+    "description": "Task and project management for individuals and teams",
+    "key_concepts": ["tasks", "projects", "deadlines", "priorities", "assignments"]
+  },
+  "components": [
+    {
+      "component_id": "create-task",
+      "component_type": "ACTION",
+      "intent": "Create a new task",
+      "invocation": {
+        "primary_phrase": "create task",
+        "alternate_phrases": ["add task", "new task", "make a task"],
+        "examples": [
+          "Create a task to review the PR",
+          "Add a task called finish report",
+          "New task: send email to client"
+        ]
+      },
+      "feedback": {
+        "success_template": "Task '{title}' has been created successfully",
+        "error_template": "Could not create task: {error}",
+        "confirmation_required": false
+      }
+    },
+    {
+      "component_id": "list-tasks",
+      "component_type": "QUERY",
+      "intent": "List all tasks or filter tasks",
+      "invocation": {
+        "primary_phrase": "list tasks",
+        "alternate_phrases": ["show tasks", "my tasks", "what are my tasks"],
+        "examples": [
+          "Show me my tasks",
+          "List all high priority tasks",
+          "What tasks are due today"
+        ]
+      },
+      "feedback": {
+        "success_template": "Here are your tasks",
+        "error_template": "Could not retrieve tasks: {error}",
+        "confirmation_required": false
+      }
+    },
+    {
+      "component_id": "complete-task",
+      "component_type": "ACTION",
+      "intent": "Mark a task as complete",
+      "invocation": {
+        "primary_phrase": "complete task",
+        "alternate_phrases": ["mark done", "finish task", "mark complete", "done with"],
+        "examples": [
+          "Mark the review task as complete",
+          "I finished the report task",
+          "Done with task 123"
+        ]
+      },
+      "feedback": {
+        "success_template": "Task marked as complete!",
+        "error_template": "Could not complete task: {error}",
+        "confirmation_required": false
+      }
+    },
+    {
+      "component_id": "delete-task",
+      "component_type": "ACTION",
+      "intent": "Delete a task",
+      "invocation": {
+        "primary_phrase": "delete task",
+        "alternate_phrases": ["remove task", "cancel task"],
+        "examples": [
+          "Delete the old task",
+          "Remove task 456"
+        ]
+      },
+      "feedback": {
+        "success_template": "Task has been deleted",
+        "error_template": "Could not delete task: {error}",
+        "confirmation_required": true,
+        "confirmation_prompt": "Are you sure you want to delete this task?"
+      }
+    },
+    {
+      "component_id": "set-priority",
+      "component_type": "ACTION",
+      "intent": "Set task priority",
+      "invocation": {
+        "primary_phrase": "set priority",
+        "alternate_phrases": ["change priority", "prioritize", "make urgent"],
+        "examples": [
+          "Set priority to high",
+          "Make this task urgent",
+          "Prioritize the client meeting task"
+        ]
+      },
+      "feedback": {
+        "success_template": "Priority updated to {priority}",
+        "error_template": "Could not update priority: {error}",
+        "confirmation_required": false
+      }
+    },
+    {
+      "component_id": "search-tasks",
+      "component_type": "QUERY",
+      "intent": "Search for tasks",
+      "invocation": {
+        "primary_phrase": "search tasks",
+        "alternate_phrases": ["find task", "look for task"],
+        "examples": [
+          "Search for tasks about meeting",
+          "Find all tasks related to client"
+        ]
+      },
+      "feedback": {
+        "success_template": "Found {count} matching tasks",
+        "error_template": "Search failed: {error}",
+        "confirmation_required": false
+      }
+    },
+    {
+      "component_id": "help",
+      "component_type": "FEEDBACK",
+      "intent": "Get help with using the task manager",
+      "invocation": {
+        "primary_phrase": "help",
+        "alternate_phrases": ["what can you do", "how do I", "help me"],
+        "examples": [
+          "Help",
+          "What can you do?",
+          "How do I create a task?"
+        ]
+      },
+      "feedback": {
+        "success_template": "I can help you manage your tasks. You can create tasks, list them, mark them complete, set priorities, and more. Just tell me what you'd like to do!",
+        "error_template": "Sorry, I couldn't load help information",
+        "confirmation_required": false
+      }
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,20 @@ requires-python = ">=3.12"
 dependencies = [
     "baml-py>=0.215.2",
     "pydantic>=2.12.5",
+    "rich>=14.2.0",
+    "typer>=0.21.0",
 ]
 
 [dependency-groups]
 dev = [
     "pyright>=1.1.407",
     "pytest>=9.0.2",
+    "pytest-asyncio>=0.25.0",
 ]
+
+[project.scripts]
+lui-sim = "lui_simulator.cli:main"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/src/lui_simulator/__init__.py
+++ b/src/lui_simulator/__init__.py
@@ -1,0 +1,13 @@
+"""LUI Simulator - Interactive Language User Interface testing tool."""
+
+from .simulator import LUISimulator
+from .context import SimulatorContext, SimulatorConfig
+from .logger import ConversationLogger, ConversationEntry
+
+__all__ = [
+    "LUISimulator",
+    "SimulatorContext",
+    "SimulatorConfig",
+    "ConversationLogger",
+    "ConversationEntry",
+]

--- a/src/lui_simulator/cli.py
+++ b/src/lui_simulator/cli.py
@@ -1,0 +1,325 @@
+"""CLI interface for the LUI Simulator."""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.markdown import Markdown
+from rich import print as rprint
+
+from .simulator import LUISimulator, load_schema_from_dict
+from .context import SimulatorConfig, SimulatorMode
+from baml_client.types import ResponseTone, FormalityLevel, ExpertiseLevel
+
+app = typer.Typer(
+    name="lui-sim",
+    help="Interactive LUI Simulator - Test Language User Interface schemas",
+    add_completion=False,
+)
+
+console = Console()
+
+
+def load_schema(schema_path: str) -> dict:
+    """Load a schema from a JSON file."""
+    path = Path(schema_path)
+    if not path.exists():
+        raise typer.BadParameter(f"Schema file not found: {schema_path}")
+
+    with open(path) as f:
+        return json.load(f)
+
+
+@app.command()
+def simulate(
+    schema_path: str = typer.Argument(..., help="Path to the LUI schema JSON file"),
+    tone: str = typer.Option("friendly", help="Response tone (professional, friendly, empathetic, direct)"),
+    formality: str = typer.Option("neutral", help="Formality level (formal, neutral, casual)"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose mode"),
+    debug: bool = typer.Option(False, "--debug", "-d", help="Enable debug mode"),
+    log_file: Optional[str] = typer.Option(None, "--log", "-l", help="Path to log file"),
+):
+    """Run an interactive simulation session with a LUI schema."""
+    # Load schema
+    try:
+        schema_data = load_schema(schema_path)
+        schema = load_schema_from_dict(schema_data)
+    except Exception as e:
+        console.print(f"[red]Error loading schema: {e}[/red]")
+        raise typer.Exit(1)
+
+    # Configure simulator
+    tone_map = {
+        "professional": ResponseTone.PROFESSIONAL,
+        "friendly": ResponseTone.FRIENDLY,
+        "empathetic": ResponseTone.EMPATHETIC,
+        "direct": ResponseTone.DIRECT,
+        "calm": ResponseTone.CALM,
+        "enthusiastic": ResponseTone.ENTHUSIASTIC,
+        "playful": ResponseTone.PLAYFUL,
+    }
+
+    formality_map = {
+        "very_formal": FormalityLevel.VERY_FORMAL,
+        "formal": FormalityLevel.FORMAL,
+        "neutral": FormalityLevel.NEUTRAL,
+        "casual": FormalityLevel.CASUAL,
+        "very_casual": FormalityLevel.VERY_CASUAL,
+    }
+
+    mode = SimulatorMode.INTERACTIVE
+    if verbose:
+        mode = SimulatorMode.VERBOSE
+    elif debug:
+        mode = SimulatorMode.DEBUG
+
+    config = SimulatorConfig(
+        tone=tone_map.get(tone.lower(), ResponseTone.FRIENDLY),
+        formality=formality_map.get(formality.lower(), FormalityLevel.NEUTRAL),
+        mode=mode,
+        log_to_file=log_file is not None,
+        log_file_path=log_file,
+    )
+
+    # Create simulator
+    simulator = LUISimulator(schema, config)
+
+    # Print welcome message
+    console.print(Panel.fit(
+        f"[bold blue]LUI Simulator[/bold blue]\n"
+        f"Schema: [green]{schema.name}[/green]\n"
+        f"Components: {len(schema.components)}\n"
+        f"Tone: {tone} | Formality: {formality}",
+        title="Session Started",
+    ))
+
+    console.print("\n[dim]Commands: 'quit' to exit, 'debug' for state, 'reset' to clear, 'help' for commands[/dim]\n")
+
+    # Interactive loop
+    while True:
+        try:
+            user_input = console.input("[bold cyan]You:[/bold cyan] ")
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n[yellow]Session ended.[/yellow]")
+            break
+
+        user_input = user_input.strip()
+
+        if not user_input:
+            continue
+
+        # Handle special commands
+        if user_input.lower() == "quit":
+            console.print("[yellow]Goodbye![/yellow]")
+            break
+
+        if user_input.lower() == "debug":
+            _show_debug_info(simulator)
+            continue
+
+        if user_input.lower() == "reset":
+            simulator.reset()
+            console.print("[yellow]Simulator reset.[/yellow]")
+            continue
+
+        if user_input.lower() == "help":
+            _show_help()
+            continue
+
+        if user_input.lower() == "transcript":
+            console.print(Panel(simulator.get_transcript(), title="Conversation Transcript"))
+            continue
+
+        if user_input.lower() == "components":
+            _show_components(simulator)
+            continue
+
+        if user_input.lower() == "save":
+            path = simulator.save_session()
+            console.print(f"[green]Session saved to: {path}[/green]")
+            continue
+
+        # Process user input
+        try:
+            result = simulator.process_input(user_input)
+
+            # Display response
+            if result.response_type.value == "ERROR":
+                console.print(f"[bold red]LUI:[/bold red] {result.response_text}\n")
+            elif result.was_ambiguous:
+                console.print(f"[bold yellow]LUI:[/bold yellow] {result.response_text}\n")
+            else:
+                console.print(f"[bold green]LUI:[/bold green] {result.response_text}\n")
+
+            # Show follow-up if available
+            if result.follow_up_suggestion:
+                console.print(f"[dim]Suggestion: {result.follow_up_suggestion}[/dim]\n")
+
+            # Verbose mode: show processing info
+            if config.mode == SimulatorMode.VERBOSE and result.intent_extracted:
+                console.print(f"[dim]Intent: {result.intent_extracted.detected_intent.intent_name} "
+                            f"(confidence: {result.intent_extracted.confidence:.2f})[/dim]")
+                console.print(f"[dim]Processing time: {result.processing_time_ms}ms[/dim]\n")
+
+        except Exception as e:
+            console.print(f"[red]Error: {e}[/red]\n")
+
+
+def _show_debug_info(simulator: LUISimulator) -> None:
+    """Display debug information."""
+    info = simulator.get_debug_info()
+
+    table = Table(title="Debug Information")
+    table.add_column("Property", style="cyan")
+    table.add_column("Value", style="green")
+
+    # Context info
+    ctx = info["context"]
+    table.add_row("Session ID", ctx["session_id"])
+    table.add_row("Started At", ctx["started_at"])
+    table.add_row("Interactions", str(ctx["interaction_count"]))
+    table.add_row("Messages", str(ctx["message_count"]))
+    table.add_row("Current State", ctx["current_state"] or "None")
+    table.add_row("Active Entity", ctx["active_entity"] or "None")
+    table.add_row("Schema", ctx["schema_name"])
+    table.add_row("Components", str(ctx["component_count"]))
+
+    # Config info
+    cfg = info["config"]
+    table.add_row("Mode", cfg["mode"])
+    table.add_row("Tone", cfg["tone"])
+    table.add_row("Formality", cfg["formality"])
+
+    console.print(table)
+
+
+def _show_components(simulator: LUISimulator) -> None:
+    """Display available components."""
+    table = Table(title="Available Components")
+    table.add_column("ID", style="cyan")
+    table.add_column("Type", style="yellow")
+    table.add_column("Intent", style="green")
+    table.add_column("Invocation", style="blue")
+
+    for comp in simulator.schema.components:
+        table.add_row(
+            comp.component_id,
+            comp.component_type.value,
+            comp.intent[:40] + "..." if len(comp.intent) > 40 else comp.intent,
+            comp.invocation.primary_phrase,
+        )
+
+    console.print(table)
+
+
+def _show_help() -> None:
+    """Display help information."""
+    help_text = """
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `quit` | Exit the simulator |
+| `debug` | Show debug information |
+| `reset` | Clear conversation and reset state |
+| `transcript` | Show conversation transcript |
+| `components` | List available components |
+| `save` | Save session to file |
+| `help` | Show this help message |
+
+## Tips
+
+- Just type naturally to interact with the LUI
+- The simulator will extract your intent and respond
+- Use `debug` to see what's happening internally
+"""
+    console.print(Markdown(help_text))
+
+
+@app.command()
+def info(schema_path: str = typer.Argument(..., help="Path to the LUI schema JSON file")):
+    """Display information about a LUI schema."""
+    try:
+        schema_data = load_schema(schema_path)
+        schema = load_schema_from_dict(schema_data)
+    except Exception as e:
+        console.print(f"[red]Error loading schema: {e}[/red]")
+        raise typer.Exit(1)
+
+    console.print(Panel.fit(
+        f"[bold]{schema.name}[/bold]\n"
+        f"ID: {schema.schema_id}\n"
+        f"Version: {schema.version}\n"
+        f"Description: {schema.description}\n\n"
+        f"Domain: {schema.domain.domain_name}\n"
+        f"Components: {len(schema.components)}\n"
+        f"Flows: {len(schema.flows) if schema.flows else 0}",
+        title="Schema Information",
+    ))
+
+    if schema.components:
+        _show_components_table(schema.components)
+
+
+def _show_components_table(components) -> None:
+    """Display components in a table."""
+    table = Table(title="Components")
+    table.add_column("ID", style="cyan")
+    table.add_column("Type", style="yellow")
+    table.add_column("Intent", style="green")
+
+    for comp in components:
+        table.add_row(
+            comp.component_id,
+            comp.component_type.value,
+            comp.intent,
+        )
+
+    console.print(table)
+
+
+@app.command()
+def validate(schema_path: str = typer.Argument(..., help="Path to the LUI schema JSON file")):
+    """Validate a LUI schema file."""
+    try:
+        schema_data = load_schema(schema_path)
+        schema = load_schema_from_dict(schema_data)
+
+        # Basic validation
+        issues = []
+
+        if not schema.name:
+            issues.append("Schema name is empty")
+
+        if not schema.components:
+            issues.append("Schema has no components")
+
+        for comp in schema.components:
+            if not comp.invocation.primary_phrase:
+                issues.append(f"Component '{comp.component_id}' has no primary invocation phrase")
+            if not comp.feedback.success_template:
+                issues.append(f"Component '{comp.component_id}' has no success template")
+
+        if issues:
+            console.print("[yellow]Validation warnings:[/yellow]")
+            for issue in issues:
+                console.print(f"  [yellow]⚠[/yellow] {issue}")
+        else:
+            console.print("[green]✓ Schema is valid[/green]")
+
+    except Exception as e:
+        console.print(f"[red]✗ Validation failed: {e}[/red]")
+        raise typer.Exit(1)
+
+
+def main():
+    """Entry point for the CLI."""
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lui_simulator/context.py
+++ b/src/lui_simulator/context.py
@@ -1,0 +1,166 @@
+"""Simulator context and configuration types."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from enum import Enum
+
+from baml_client.types import (
+    ConversationContext,
+    ConversationMessage,
+    MessageRole,
+    ResponseStyle,
+    ResponseTone,
+    FormalityLevel,
+    UserContext,
+    ExpertiseLevel,
+    InterfaceSchema,
+)
+
+
+class SimulatorMode(Enum):
+    """Operating modes for the simulator."""
+
+    INTERACTIVE = "interactive"  # Normal conversation mode
+    DEBUG = "debug"  # Shows internal state
+    VERBOSE = "verbose"  # Shows all processing steps
+    QUIET = "quiet"  # Minimal output
+
+
+@dataclass
+class SimulatorConfig:
+    """Configuration for the LUI simulator."""
+
+    # Response style settings
+    tone: ResponseTone = ResponseTone.FRIENDLY
+    formality: FormalityLevel = FormalityLevel.NEUTRAL
+
+    # Simulation settings
+    simulate_latency: bool = False
+    latency_ms: int = 500
+    auto_confirm: bool = False  # Auto-confirm confirmation prompts
+
+    # Context settings
+    max_history_length: int = 10
+    expertise_level: ExpertiseLevel = ExpertiseLevel.INTERMEDIATE
+
+    # Debug settings
+    mode: SimulatorMode = SimulatorMode.INTERACTIVE
+    log_to_file: bool = False
+    log_file_path: str | None = None
+
+    def get_response_style(self) -> ResponseStyle:
+        """Create a ResponseStyle from config settings."""
+        return ResponseStyle(
+            tone=self.tone,
+            formality=self.formality,
+            personality=None,
+            brand_voice=None,
+        )
+
+    def get_user_context(self, interaction_count: int = 0) -> UserContext:
+        """Create a UserContext from config settings."""
+        return UserContext(
+            user_id="simulator-user",
+            preferences=None,
+            interaction_count=interaction_count,
+            expertise_level=self.expertise_level,
+            accessibility_needs=None,
+            locale="en-US",
+            previous_responses=None,
+        )
+
+
+@dataclass
+class SimulatorContext:
+    """Manages conversation context and state for the simulator."""
+
+    schema: InterfaceSchema
+    config: SimulatorConfig = field(default_factory=SimulatorConfig)
+
+    # Conversation state
+    messages: list[ConversationMessage] = field(default_factory=list)
+    current_state: str | None = None
+    active_entity: str | None = None
+    active_flow_id: str | None = None
+
+    # Session metadata
+    session_id: str = field(default_factory=lambda: datetime.now().strftime("%Y%m%d_%H%M%S"))
+    started_at: datetime = field(default_factory=datetime.now)
+    interaction_count: int = 0
+
+    # Variable storage for flows
+    variables: dict[str, Any] = field(default_factory=dict)
+
+    def add_user_message(self, content: str) -> None:
+        """Add a user message to the conversation history."""
+        message = ConversationMessage(
+            role=MessageRole.USER,
+            content=content,
+            timestamp=datetime.now().isoformat(),
+            extracted_intent=None,
+        )
+        self.messages.append(message)
+        self._trim_history()
+
+    def add_assistant_message(self, content: str) -> None:
+        """Add an assistant message to the conversation history."""
+        message = ConversationMessage(
+            role=MessageRole.ASSISTANT,
+            content=content,
+            timestamp=datetime.now().isoformat(),
+            extracted_intent=None,
+        )
+        self.messages.append(message)
+        self._trim_history()
+
+    def _trim_history(self) -> None:
+        """Keep only the most recent messages based on config."""
+        if len(self.messages) > self.config.max_history_length:
+            self.messages = self.messages[-self.config.max_history_length :]
+
+    def get_conversation_context(self) -> ConversationContext:
+        """Get the current conversation context for BAML functions."""
+        return ConversationContext(
+            recent_messages=self.messages,
+            current_state=self.current_state,
+            active_entity=self.active_entity,
+            user_preferences=None,
+        )
+
+    def set_variable(self, name: str, value: Any) -> None:
+        """Store a variable in the context."""
+        self.variables[name] = value
+
+    def get_variable(self, name: str, default: Any = None) -> Any:
+        """Retrieve a variable from the context."""
+        return self.variables.get(name, default)
+
+    def clear_variables(self) -> None:
+        """Clear all stored variables."""
+        self.variables.clear()
+
+    def reset(self) -> None:
+        """Reset the context to initial state."""
+        self.messages.clear()
+        self.current_state = None
+        self.active_entity = None
+        self.active_flow_id = None
+        self.variables.clear()
+        self.interaction_count = 0
+
+    def get_debug_info(self) -> dict[str, Any]:
+        """Get debug information about the current context."""
+        return {
+            "session_id": self.session_id,
+            "started_at": self.started_at.isoformat(),
+            "interaction_count": self.interaction_count,
+            "message_count": len(self.messages),
+            "current_state": self.current_state,
+            "active_entity": self.active_entity,
+            "active_flow_id": self.active_flow_id,
+            "variables": self.variables,
+            "schema_name": self.schema.name,
+            "component_count": len(self.schema.components),
+            "flow_count": len(self.schema.flows) if self.schema.flows else 0,
+        }

--- a/src/lui_simulator/logger.py
+++ b/src/lui_simulator/logger.py
@@ -1,0 +1,212 @@
+"""Conversation logging for the LUI simulator."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from enum import Enum
+import json
+from pathlib import Path
+
+
+class EntryType(Enum):
+    """Types of log entries."""
+
+    USER_INPUT = "user_input"
+    INTENT_EXTRACTED = "intent_extracted"
+    ACTION_EXECUTED = "action_executed"
+    RESPONSE_GENERATED = "response_generated"
+    ERROR = "error"
+    DEBUG = "debug"
+    SYSTEM = "system"
+
+
+@dataclass
+class ConversationEntry:
+    """A single entry in the conversation log."""
+
+    entry_type: EntryType
+    timestamp: datetime
+    content: str
+    metadata: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert entry to dictionary for serialization."""
+        return {
+            "type": self.entry_type.value,
+            "timestamp": self.timestamp.isoformat(),
+            "content": self.content,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ConversationEntry":
+        """Create entry from dictionary."""
+        return cls(
+            entry_type=EntryType(data["type"]),
+            timestamp=datetime.fromisoformat(data["timestamp"]),
+            content=data["content"],
+            metadata=data.get("metadata"),
+        )
+
+
+@dataclass
+class ConversationLogger:
+    """Logs conversation interactions for debugging and analysis."""
+
+    session_id: str
+    entries: list[ConversationEntry] = field(default_factory=list)
+    log_file_path: Path | None = None
+
+    def log(
+        self,
+        entry_type: EntryType,
+        content: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> ConversationEntry:
+        """Add a new log entry."""
+        entry = ConversationEntry(
+            entry_type=entry_type,
+            timestamp=datetime.now(),
+            content=content,
+            metadata=metadata,
+        )
+        self.entries.append(entry)
+
+        # Write to file if configured
+        if self.log_file_path:
+            self._append_to_file(entry)
+
+        return entry
+
+    def log_user_input(self, user_input: str) -> ConversationEntry:
+        """Log a user input."""
+        return self.log(EntryType.USER_INPUT, user_input)
+
+    def log_intent(
+        self,
+        intent_name: str,
+        confidence: float,
+        target_component: str,
+        parameters: dict[str, str] | None = None,
+    ) -> ConversationEntry:
+        """Log an extracted intent."""
+        return self.log(
+            EntryType.INTENT_EXTRACTED,
+            f"Intent: {intent_name} -> {target_component}",
+            metadata={
+                "intent_name": intent_name,
+                "confidence": confidence,
+                "target_component": target_component,
+                "parameters": parameters,
+            },
+        )
+
+    def log_action(
+        self,
+        action_name: str,
+        status: str,
+        result_data: str | None = None,
+    ) -> ConversationEntry:
+        """Log an action execution."""
+        return self.log(
+            EntryType.ACTION_EXECUTED,
+            f"Action: {action_name} -> {status}",
+            metadata={
+                "action_name": action_name,
+                "status": status,
+                "result_data": result_data,
+            },
+        )
+
+    def log_response(
+        self,
+        response_text: str,
+        response_type: str,
+        has_follow_up: bool = False,
+    ) -> ConversationEntry:
+        """Log a generated response."""
+        return self.log(
+            EntryType.RESPONSE_GENERATED,
+            response_text,
+            metadata={
+                "response_type": response_type,
+                "has_follow_up": has_follow_up,
+            },
+        )
+
+    def log_error(self, error_message: str, exception: Exception | None = None) -> ConversationEntry:
+        """Log an error."""
+        metadata = {"error_type": type(exception).__name__} if exception else None
+        return self.log(EntryType.ERROR, error_message, metadata=metadata)
+
+    def log_debug(self, message: str, data: dict[str, Any] | None = None) -> ConversationEntry:
+        """Log debug information."""
+        return self.log(EntryType.DEBUG, message, metadata=data)
+
+    def log_system(self, message: str) -> ConversationEntry:
+        """Log a system message."""
+        return self.log(EntryType.SYSTEM, message)
+
+    def _append_to_file(self, entry: ConversationEntry) -> None:
+        """Append an entry to the log file."""
+        if not self.log_file_path:
+            return
+
+        self.log_file_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.log_file_path, "a") as f:
+            f.write(json.dumps(entry.to_dict()) + "\n")
+
+    def save_session(self, path: Path | None = None) -> Path:
+        """Save the entire session to a JSON file."""
+        save_path = path or self.log_file_path or Path(f"logs/session_{self.session_id}.json")
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+
+        session_data = {
+            "session_id": self.session_id,
+            "entry_count": len(self.entries),
+            "entries": [e.to_dict() for e in self.entries],
+        }
+
+        with open(save_path, "w") as f:
+            json.dump(session_data, f, indent=2)
+
+        return save_path
+
+    @classmethod
+    def load_session(cls, path: Path) -> "ConversationLogger":
+        """Load a session from a JSON file."""
+        with open(path) as f:
+            data = json.load(f)
+
+        logger = cls(session_id=data["session_id"])
+        logger.entries = [ConversationEntry.from_dict(e) for e in data["entries"]]
+        return logger
+
+    def get_summary(self) -> dict[str, Any]:
+        """Get a summary of the conversation log."""
+        type_counts: dict[str, int] = {}
+        for entry in self.entries:
+            type_name = entry.entry_type.value
+            type_counts[type_name] = type_counts.get(type_name, 0) + 1
+
+        return {
+            "session_id": self.session_id,
+            "total_entries": len(self.entries),
+            "entry_counts": type_counts,
+            "first_entry": self.entries[0].timestamp.isoformat() if self.entries else None,
+            "last_entry": self.entries[-1].timestamp.isoformat() if self.entries else None,
+        }
+
+    def get_conversation_transcript(self) -> str:
+        """Get a human-readable transcript of the conversation."""
+        lines = []
+        for entry in self.entries:
+            if entry.entry_type == EntryType.USER_INPUT:
+                lines.append(f"User: {entry.content}")
+            elif entry.entry_type == EntryType.RESPONSE_GENERATED:
+                lines.append(f"LUI: {entry.content}")
+            elif entry.entry_type == EntryType.ERROR:
+                lines.append(f"[Error: {entry.content}]")
+            elif entry.entry_type == EntryType.SYSTEM:
+                lines.append(f"[System: {entry.content}]")
+        return "\n".join(lines)

--- a/src/lui_simulator/simulator.py
+++ b/src/lui_simulator/simulator.py
@@ -1,0 +1,343 @@
+"""Core LUI Simulator implementation."""
+
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from baml_client import b
+from baml_client.types import (
+    InterfaceSchema,
+    LUIComponent,
+    ActionResult,
+    ResultStatus,
+    ResultMetadata,
+    GeneratedResponse,
+    ResponseType,
+    IntentExtraction,
+)
+
+from .context import SimulatorContext, SimulatorConfig, SimulatorMode
+from .logger import ConversationLogger
+
+
+@dataclass
+class SimulationResult:
+    """Result of processing a user input."""
+
+    response_text: str
+    response_type: ResponseType
+    intent_extracted: IntentExtraction | None = None
+    action_result: ActionResult | None = None
+    follow_up_suggestion: str | None = None
+    processing_time_ms: int = 0
+    was_ambiguous: bool = False
+    required_clarification: bool = False
+
+
+class LUISimulator:
+    """Interactive simulator for testing LUI schemas."""
+
+    def __init__(
+        self,
+        schema: InterfaceSchema,
+        config: SimulatorConfig | None = None,
+    ):
+        """Initialize the simulator with a schema and optional config."""
+        self.config = config or SimulatorConfig()
+        self.context = SimulatorContext(schema=schema, config=self.config)
+        log_path = Path(self.config.log_file_path) if self.config.log_to_file and self.config.log_file_path else None
+        self.logger = ConversationLogger(
+            session_id=self.context.session_id,
+            log_file_path=log_path,
+        )
+
+        # Log session start
+        self.logger.log_system(f"Simulator started with schema: {schema.name}")
+
+    @property
+    def schema(self) -> InterfaceSchema:
+        """Get the loaded schema."""
+        return self.context.schema
+
+    def process_input(self, user_input: str) -> SimulationResult:
+        """Process a user input and generate a response."""
+        start_time = datetime.now()
+        self.context.interaction_count += 1
+
+        # Log user input
+        self.logger.log_user_input(user_input)
+        self.context.add_user_message(user_input)
+
+        try:
+            # Extract intent
+            intent = self._extract_intent(user_input)
+
+            if self.config.mode == SimulatorMode.VERBOSE:
+                self.logger.log_debug(
+                    f"Intent extracted: {intent.detected_intent.intent_name}",
+                    {"confidence": intent.confidence},
+                )
+
+            # Check for ambiguity
+            if intent.ambiguity and intent.ambiguity.is_ambiguous:
+                clarification = intent.suggested_clarification or intent.ambiguity.disambiguation_question
+                self.context.add_assistant_message(clarification)
+                self.logger.log_response(clarification, "CLARIFICATION")
+
+                return SimulationResult(
+                    response_text=clarification,
+                    response_type=ResponseType.CLARIFICATION,
+                    intent_extracted=intent,
+                    was_ambiguous=True,
+                    required_clarification=True,
+                    processing_time_ms=self._calc_time_ms(start_time),
+                )
+
+            # Log intent
+            self.logger.log_intent(
+                intent.detected_intent.intent_name,
+                intent.confidence,
+                intent.detected_intent.target_component,
+                {p.parameter_name: p.extracted_value for p in intent.extracted_parameters},
+            )
+
+            # Get target component
+            component = self._get_component(intent.detected_intent.target_component)
+
+            if not component:
+                error_response = f"I couldn't find the component '{intent.detected_intent.target_component}' to handle that request."
+                self.context.add_assistant_message(error_response)
+                self.logger.log_error(f"Component not found: {intent.detected_intent.target_component}")
+
+                return SimulationResult(
+                    response_text=error_response,
+                    response_type=ResponseType.ERROR,
+                    intent_extracted=intent,
+                    processing_time_ms=self._calc_time_ms(start_time),
+                )
+
+            # Simulate action execution
+            action_result = self._simulate_action(intent, component)
+            self.logger.log_action(
+                component.component_id,
+                action_result.status.value,
+                action_result.data,
+            )
+
+            # Generate response
+            response = self._generate_response(action_result, component)
+
+            # Update context
+            self.context.add_assistant_message(response.response_text)
+            self.context.current_state = f"after_{component.component_id}"
+
+            # Log response
+            self.logger.log_response(
+                response.response_text,
+                response.response_type.value,
+                response.follow_up is not None,
+            )
+
+            return SimulationResult(
+                response_text=response.response_text,
+                response_type=response.response_type,
+                intent_extracted=intent,
+                action_result=action_result,
+                follow_up_suggestion=response.follow_up.suggested_action if response.follow_up else None,
+                processing_time_ms=self._calc_time_ms(start_time),
+            )
+
+        except Exception as e:
+            error_message = f"An error occurred: {str(e)}"
+            self.logger.log_error(error_message, e)
+
+            return SimulationResult(
+                response_text=error_message,
+                response_type=ResponseType.ERROR,
+                processing_time_ms=self._calc_time_ms(start_time),
+            )
+
+    def _extract_intent(self, user_input: str) -> IntentExtraction:
+        """Extract intent from user input using BAML."""
+        return b.ExtractIntent(
+            user_input=user_input,
+            interface_schema=self.schema,
+            conversation_context=self.context.get_conversation_context(),
+        )
+
+    def _get_component(self, component_id: str) -> LUIComponent | None:
+        """Find a component by ID in the schema."""
+        for component in self.schema.components:
+            if component.component_id == component_id:
+                return component
+        return None
+
+    def _simulate_action(
+        self,
+        intent: IntentExtraction,
+        component: LUIComponent,
+    ) -> ActionResult:
+        """Simulate executing an action based on the intent."""
+        # Simulate latency if configured
+        if self.config.simulate_latency:
+            time.sleep(self.config.latency_ms / 1000)
+
+        # Build simulated result based on intent
+        params = {p.parameter_name: p.extracted_value for p in intent.extracted_parameters}
+
+        # Generate simulated data based on component type
+        simulated_data = self._generate_simulated_data(component, params)
+
+        return ActionResult(
+            status=ResultStatus.SUCCESS,
+            data=simulated_data,
+            error_message=None,
+            metadata=ResultMetadata(
+                timestamp=datetime.now().isoformat(),
+                affected_count=1,
+                warnings=None,
+                debug_info=f"Simulated execution of {component.component_id}",
+                related_actions=None,
+            ),
+            affected_entities=[f"simulated-{component.component_id}-result"],
+            execution_time_ms=self.config.latency_ms if self.config.simulate_latency else 50,
+        )
+
+    def _generate_simulated_data(
+        self,
+        component: LUIComponent,
+        params: dict[str, str],
+    ) -> str:
+        """Generate simulated result data based on component and parameters."""
+        component_type = component.component_type.value
+
+        if component_type == "ACTION":
+            if params:
+                param_str = ", ".join(f"{k}='{v}'" for k, v in params.items())
+                return f"Action '{component.intent}' completed successfully with {param_str}"
+            return f"Action '{component.intent}' completed successfully"
+
+        elif component_type == "QUERY":
+            return f"Found 5 results matching your query for '{component.intent}'"
+
+        elif component_type == "NAVIGATION":
+            return f"Navigated to {component.intent}"
+
+        elif component_type == "INPUT":
+            if params:
+                return f"Input received: {params}"
+            return "Awaiting input..."
+
+        elif component_type == "CONFIRMATION":
+            return "Confirmed"
+
+        else:
+            return f"Simulated result for {component.component_id}"
+
+    def _generate_response(
+        self,
+        action_result: ActionResult,
+        component: LUIComponent,
+    ) -> GeneratedResponse:
+        """Generate a natural language response using BAML."""
+        return b.GenerateResponse(
+            action_result=action_result,
+            component=component,
+            user_context=self.config.get_user_context(self.context.interaction_count),
+            style=self.config.get_response_style(),
+        )
+
+    def _calc_time_ms(self, start_time: datetime) -> int:
+        """Calculate elapsed time in milliseconds."""
+        return int((datetime.now() - start_time).total_seconds() * 1000)
+
+    def get_debug_info(self) -> dict[str, Any]:
+        """Get debug information about the simulator state."""
+        return {
+            "context": self.context.get_debug_info(),
+            "config": {
+                "mode": self.config.mode.value,
+                "tone": self.config.tone.value,
+                "formality": self.config.formality.value,
+                "simulate_latency": self.config.simulate_latency,
+            },
+            "log_summary": self.logger.get_summary(),
+        }
+
+    def get_transcript(self) -> str:
+        """Get a transcript of the conversation."""
+        return self.logger.get_conversation_transcript()
+
+    def reset(self) -> None:
+        """Reset the simulator to initial state."""
+        self.context.reset()
+        self.logger.log_system("Simulator reset")
+
+    def save_session(self) -> str:
+        """Save the current session and return the file path."""
+        path = self.logger.save_session()
+        return str(path)
+
+
+def load_schema_from_dict(data: dict[str, Any]) -> InterfaceSchema:
+    """Load an InterfaceSchema from a dictionary."""
+    from baml_client.types import (
+        DomainInfo,
+        LUIComponent,
+        LUIComponentType,
+        InvocationPattern,
+        FeedbackConfig,
+    )
+
+    # Parse domain
+    domain_data = data.get("domain", {})
+    domain = DomainInfo(
+        domain_name=domain_data.get("domain_name", "unknown"),
+        subdomain=domain_data.get("subdomain"),
+        description=domain_data.get("description", ""),
+        key_concepts=domain_data.get("key_concepts", []),
+        terminology=None,
+    )
+
+    # Parse components
+    components = []
+    for comp_data in data.get("components", []):
+        invocation = InvocationPattern(
+            primary_phrase=comp_data.get("invocation", {}).get("primary_phrase", ""),
+            alternate_phrases=comp_data.get("invocation", {}).get("alternate_phrases", []),
+            examples=comp_data.get("invocation", {}).get("examples", []),
+            context_requirements=None,
+        )
+
+        feedback = FeedbackConfig(
+            success_template=comp_data.get("feedback", {}).get("success_template", "Done"),
+            error_template=comp_data.get("feedback", {}).get("error_template", "Failed"),
+            progress_template=comp_data.get("feedback", {}).get("progress_template"),
+            confirmation_required=comp_data.get("feedback", {}).get("confirmation_required", False),
+            confirmation_prompt=comp_data.get("feedback", {}).get("confirmation_prompt"),
+        )
+
+        component = LUIComponent(
+            component_id=comp_data.get("component_id", ""),
+            component_type=LUIComponentType[comp_data.get("component_type", "ACTION")],
+            intent=comp_data.get("intent", ""),
+            invocation=invocation,
+            parameters=[],
+            feedback=feedback,
+            accessibility=None,
+        )
+        components.append(component)
+
+    return InterfaceSchema(
+        schema_id=data.get("schema_id", "unknown"),
+        name=data.get("name", "Unknown Schema"),
+        description=data.get("description", ""),
+        version=data.get("version", "1.0.0"),
+        domain=domain,
+        components=components,
+        flows=[],
+        entities=[],
+        global_context=None,
+    )

--- a/tests/test_lui_simulator.py
+++ b/tests/test_lui_simulator.py
@@ -1,0 +1,489 @@
+"""Tests for LUI Simulator."""
+
+import pytest
+from datetime import datetime
+from pathlib import Path
+import json
+import tempfile
+
+from baml_client.types import (
+    InterfaceSchema,
+    DomainInfo,
+    LUIComponent,
+    LUIComponentType,
+    InvocationPattern,
+    FeedbackConfig,
+    ResponseTone,
+    FormalityLevel,
+    ExpertiseLevel,
+    MessageRole,
+    ResponseType,
+)
+
+# Import simulator modules
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from lui_simulator.context import SimulatorContext, SimulatorConfig, SimulatorMode
+from lui_simulator.logger import ConversationLogger, ConversationEntry, EntryType
+
+
+# ============================================
+# Test Fixtures
+# ============================================
+
+@pytest.fixture
+def sample_component() -> LUIComponent:
+    """Create a sample LUI component for testing."""
+    return LUIComponent(
+        component_id="create-task",
+        component_type=LUIComponentType.ACTION,
+        intent="Create a new task",
+        invocation=InvocationPattern(
+            primary_phrase="create task",
+            alternate_phrases=["add task", "new task"],
+            examples=["Create a task to review code"],
+            context_requirements=None,
+        ),
+        parameters=[],
+        feedback=FeedbackConfig(
+            success_template="Task '{title}' created successfully",
+            error_template="Could not create task: {error}",
+            progress_template=None,
+            confirmation_required=False,
+            confirmation_prompt=None,
+        ),
+        accessibility=None,
+    )
+
+
+@pytest.fixture
+def sample_schema(sample_component: LUIComponent) -> InterfaceSchema:
+    """Create a sample interface schema for testing."""
+    domain = DomainInfo(
+        domain_name="task-management",
+        subdomain=None,
+        description="Task tracking",
+        key_concepts=["tasks", "projects"],
+        terminology=None,
+    )
+
+    list_component = LUIComponent(
+        component_id="list-tasks",
+        component_type=LUIComponentType.QUERY,
+        intent="List all tasks",
+        invocation=InvocationPattern(
+            primary_phrase="list tasks",
+            alternate_phrases=["show tasks", "my tasks"],
+            examples=["Show me my tasks"],
+            context_requirements=None,
+        ),
+        parameters=[],
+        feedback=FeedbackConfig(
+            success_template="Here are your tasks",
+            error_template="Could not list tasks",
+            progress_template=None,
+            confirmation_required=False,
+            confirmation_prompt=None,
+        ),
+        accessibility=None,
+    )
+
+    return InterfaceSchema(
+        schema_id="test-schema-v1",
+        name="Test Task Manager",
+        description="A test task management schema",
+        version="1.0.0",
+        domain=domain,
+        components=[sample_component, list_component],
+        flows=[],
+        entities=[],
+        global_context=None,
+    )
+
+
+@pytest.fixture
+def simulator_config() -> SimulatorConfig:
+    """Create a simulator configuration for testing."""
+    return SimulatorConfig(
+        tone=ResponseTone.FRIENDLY,
+        formality=FormalityLevel.NEUTRAL,
+        mode=SimulatorMode.INTERACTIVE,
+        max_history_length=5,
+        expertise_level=ExpertiseLevel.INTERMEDIATE,
+    )
+
+
+# ============================================
+# Test SimulatorConfig
+# ============================================
+
+class TestSimulatorConfig:
+    """Test SimulatorConfig creation and methods."""
+
+    def test_default_config(self):
+        """Test creating default configuration."""
+        config = SimulatorConfig()
+
+        assert config.tone == ResponseTone.FRIENDLY
+        assert config.formality == FormalityLevel.NEUTRAL
+        assert config.mode == SimulatorMode.INTERACTIVE
+        assert config.simulate_latency is False
+        assert config.max_history_length == 10
+
+    def test_get_response_style(self):
+        """Test getting response style from config."""
+        config = SimulatorConfig(
+            tone=ResponseTone.PROFESSIONAL,
+            formality=FormalityLevel.FORMAL,
+        )
+
+        style = config.get_response_style()
+
+        assert style.tone == ResponseTone.PROFESSIONAL
+        assert style.formality == FormalityLevel.FORMAL
+
+    def test_get_user_context(self):
+        """Test getting user context from config."""
+        config = SimulatorConfig(expertise_level=ExpertiseLevel.EXPERT)
+
+        context = config.get_user_context(interaction_count=10)
+
+        assert context.user_id == "simulator-user"
+        assert context.expertise_level == ExpertiseLevel.EXPERT
+        assert context.interaction_count == 10
+
+
+# ============================================
+# Test SimulatorContext
+# ============================================
+
+class TestSimulatorContext:
+    """Test SimulatorContext state management."""
+
+    def test_create_context(self, sample_schema: InterfaceSchema):
+        """Test creating a simulator context."""
+        context = SimulatorContext(schema=sample_schema)
+
+        assert context.schema == sample_schema
+        assert context.interaction_count == 0
+        assert len(context.messages) == 0
+        assert context.current_state is None
+
+    def test_add_user_message(self, sample_schema: InterfaceSchema):
+        """Test adding a user message."""
+        context = SimulatorContext(schema=sample_schema)
+
+        context.add_user_message("Create a new task")
+
+        assert len(context.messages) == 1
+        assert context.messages[0].role == MessageRole.USER
+        assert context.messages[0].content == "Create a new task"
+
+    def test_add_assistant_message(self, sample_schema: InterfaceSchema):
+        """Test adding an assistant message."""
+        context = SimulatorContext(schema=sample_schema)
+
+        context.add_assistant_message("Task created!")
+
+        assert len(context.messages) == 1
+        assert context.messages[0].role == MessageRole.ASSISTANT
+
+    def test_trim_history(self, sample_schema: InterfaceSchema):
+        """Test that history is trimmed to max length."""
+        config = SimulatorConfig(max_history_length=3)
+        context = SimulatorContext(schema=sample_schema, config=config)
+
+        # Add more messages than max
+        for i in range(5):
+            context.add_user_message(f"Message {i}")
+
+        assert len(context.messages) == 3
+        assert context.messages[0].content == "Message 2"
+
+    def test_set_and_get_variable(self, sample_schema: InterfaceSchema):
+        """Test variable storage."""
+        context = SimulatorContext(schema=sample_schema)
+
+        context.set_variable("task_id", "123")
+        context.set_variable("priority", "high")
+
+        assert context.get_variable("task_id") == "123"
+        assert context.get_variable("priority") == "high"
+        assert context.get_variable("missing", "default") == "default"
+
+    def test_reset(self, sample_schema: InterfaceSchema):
+        """Test resetting context."""
+        context = SimulatorContext(schema=sample_schema)
+        context.add_user_message("Test")
+        context.current_state = "some-state"
+        context.set_variable("key", "value")
+        context.interaction_count = 5
+
+        context.reset()
+
+        assert len(context.messages) == 0
+        assert context.current_state is None
+        assert context.get_variable("key") is None
+        assert context.interaction_count == 0
+
+    def test_get_conversation_context(self, sample_schema: InterfaceSchema):
+        """Test getting conversation context for BAML."""
+        context = SimulatorContext(schema=sample_schema)
+        context.add_user_message("Hello")
+        context.current_state = "greeting"
+        context.active_entity = "user-1"
+
+        conv_context = context.get_conversation_context()
+
+        assert len(conv_context.recent_messages) == 1
+        assert conv_context.current_state == "greeting"
+        assert conv_context.active_entity == "user-1"
+
+    def test_get_debug_info(self, sample_schema: InterfaceSchema):
+        """Test getting debug information."""
+        context = SimulatorContext(schema=sample_schema)
+        context.interaction_count = 3
+        context.current_state = "active"
+
+        info = context.get_debug_info()
+
+        assert info["interaction_count"] == 3
+        assert info["current_state"] == "active"
+        assert info["schema_name"] == "Test Task Manager"
+        assert info["component_count"] == 2
+
+
+# ============================================
+# Test ConversationLogger
+# ============================================
+
+class TestConversationLogger:
+    """Test conversation logging functionality."""
+
+    def test_create_logger(self):
+        """Test creating a conversation logger."""
+        logger = ConversationLogger(session_id="test-session")
+
+        assert logger.session_id == "test-session"
+        assert len(logger.entries) == 0
+
+    def test_log_user_input(self):
+        """Test logging user input."""
+        logger = ConversationLogger(session_id="test")
+
+        entry = logger.log_user_input("Hello, world!")
+
+        assert entry.entry_type == EntryType.USER_INPUT
+        assert entry.content == "Hello, world!"
+        assert len(logger.entries) == 1
+
+    def test_log_intent(self):
+        """Test logging extracted intent."""
+        logger = ConversationLogger(session_id="test")
+
+        entry = logger.log_intent(
+            intent_name="CreateTask",
+            confidence=0.95,
+            target_component="create-task",
+            parameters={"title": "Review PR"},
+        )
+
+        assert entry.entry_type == EntryType.INTENT_EXTRACTED
+        assert entry.metadata["confidence"] == 0.95
+        assert entry.metadata["parameters"]["title"] == "Review PR"
+
+    def test_log_action(self):
+        """Test logging action execution."""
+        logger = ConversationLogger(session_id="test")
+
+        entry = logger.log_action(
+            action_name="create-task",
+            status="SUCCESS",
+            result_data="Task created",
+        )
+
+        assert entry.entry_type == EntryType.ACTION_EXECUTED
+        assert entry.metadata["status"] == "SUCCESS"
+
+    def test_log_response(self):
+        """Test logging generated response."""
+        logger = ConversationLogger(session_id="test")
+
+        entry = logger.log_response(
+            response_text="Task created successfully!",
+            response_type="CONFIRMATION",
+            has_follow_up=True,
+        )
+
+        assert entry.entry_type == EntryType.RESPONSE_GENERATED
+        assert entry.metadata["has_follow_up"] is True
+
+    def test_log_error(self):
+        """Test logging errors."""
+        logger = ConversationLogger(session_id="test")
+
+        entry = logger.log_error("Something went wrong", ValueError("test"))
+
+        assert entry.entry_type == EntryType.ERROR
+        assert entry.metadata["error_type"] == "ValueError"
+
+    def test_get_summary(self):
+        """Test getting log summary."""
+        logger = ConversationLogger(session_id="test")
+        logger.log_user_input("Hello")
+        logger.log_response("Hi there!", "RESULT")
+        logger.log_user_input("Create task")
+
+        summary = logger.get_summary()
+
+        assert summary["total_entries"] == 3
+        assert summary["entry_counts"]["user_input"] == 2
+        assert summary["entry_counts"]["response_generated"] == 1
+
+    def test_get_transcript(self):
+        """Test getting conversation transcript."""
+        logger = ConversationLogger(session_id="test")
+        logger.log_user_input("Hello")
+        logger.log_response("Hi there!", "RESULT")
+        logger.log_user_input("Create task")
+        logger.log_response("Task created!", "CONFIRMATION")
+
+        transcript = logger.get_conversation_transcript()
+
+        assert "User: Hello" in transcript
+        assert "LUI: Hi there!" in transcript
+        assert "User: Create task" in transcript
+        assert "LUI: Task created!" in transcript
+
+    def test_save_and_load_session(self):
+        """Test saving and loading session."""
+        logger = ConversationLogger(session_id="test-save")
+        logger.log_user_input("Test message")
+        logger.log_response("Test response", "RESULT")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_path = Path(tmpdir) / "session.json"
+            logger.save_session(save_path)
+
+            # Load and verify
+            loaded = ConversationLogger.load_session(save_path)
+
+            assert loaded.session_id == "test-save"
+            assert len(loaded.entries) == 2
+            assert loaded.entries[0].content == "Test message"
+
+
+# ============================================
+# Test ConversationEntry
+# ============================================
+
+class TestConversationEntry:
+    """Test ConversationEntry serialization."""
+
+    def test_to_dict(self):
+        """Test converting entry to dictionary."""
+        entry = ConversationEntry(
+            entry_type=EntryType.USER_INPUT,
+            timestamp=datetime(2025, 1, 15, 10, 30, 0),
+            content="Hello",
+            metadata={"key": "value"},
+        )
+
+        data = entry.to_dict()
+
+        assert data["type"] == "user_input"
+        assert data["content"] == "Hello"
+        assert data["metadata"]["key"] == "value"
+
+    def test_from_dict(self):
+        """Test creating entry from dictionary."""
+        data = {
+            "type": "user_input",
+            "timestamp": "2025-01-15T10:30:00",
+            "content": "Hello",
+            "metadata": {"key": "value"},
+        }
+
+        entry = ConversationEntry.from_dict(data)
+
+        assert entry.entry_type == EntryType.USER_INPUT
+        assert entry.content == "Hello"
+        assert entry.metadata["key"] == "value"
+
+
+# ============================================
+# Test Schema Loading
+# ============================================
+
+class TestSchemaLoading:
+    """Test schema loading functionality."""
+
+    def test_load_schema_from_dict(self):
+        """Test loading schema from dictionary."""
+        from lui_simulator.simulator import load_schema_from_dict
+
+        data = {
+            "schema_id": "test-v1",
+            "name": "Test Schema",
+            "description": "A test schema",
+            "version": "1.0.0",
+            "domain": {
+                "domain_name": "testing",
+                "description": "For testing",
+                "key_concepts": ["tests"],
+            },
+            "components": [
+                {
+                    "component_id": "test-action",
+                    "component_type": "ACTION",
+                    "intent": "Do a test action",
+                    "invocation": {
+                        "primary_phrase": "test action",
+                        "alternate_phrases": ["do test"],
+                        "examples": ["Run a test"],
+                    },
+                    "feedback": {
+                        "success_template": "Test completed",
+                        "error_template": "Test failed",
+                    },
+                }
+            ],
+        }
+
+        schema = load_schema_from_dict(data)
+
+        assert schema.schema_id == "test-v1"
+        assert schema.name == "Test Schema"
+        assert len(schema.components) == 1
+        assert schema.components[0].component_id == "test-action"
+        assert schema.components[0].component_type == LUIComponentType.ACTION
+
+    def test_load_example_schema(self):
+        """Test loading the example schema file."""
+        from lui_simulator.simulator import load_schema_from_dict
+
+        schema_path = Path(__file__).parent.parent / "examples" / "task_manager_schema.json"
+
+        if schema_path.exists():
+            with open(schema_path) as f:
+                data = json.load(f)
+
+            schema = load_schema_from_dict(data)
+
+            assert schema.name == "Task Manager LUI"
+            assert len(schema.components) == 7
+
+
+# ============================================
+# Test SimulatorMode
+# ============================================
+
+class TestSimulatorMode:
+    """Test simulator mode enum."""
+
+    def test_mode_values(self):
+        """Verify all simulator modes exist."""
+        expected = {"INTERACTIVE", "DEBUG", "VERBOSE", "QUIET"}
+        actual = {m.name for m in SimulatorMode}
+        assert actual == expected

--- a/uv.lock
+++ b/uv.lock
@@ -18,24 +18,30 @@ source = { virtual = "." }
 dependencies = [
     { name = "baml-py" },
     { name = "pydantic" },
+    { name = "rich" },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "baml-py", specifier = ">=0.215.2" },
     { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "rich", specifier = ">=14.2.0" },
+    { name = "typer", specifier = ">=0.21.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pyright", specifier = ">=1.1.407" },
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=0.25.0" },
 ]
 
 [[package]]
@@ -54,6 +60,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -69,6 +87,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -220,6 +259,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/30/ff9ede605e3bd086b4dd842499814e128500621f7951ca1e5ce84bbf61b1/typer-0.21.0.tar.gz", hash = "sha256:c87c0d2b6eee3b49c5c64649ec92425492c14488096dfbc8a0c2799b2f6f9c53", size = 106781, upload-time = "2025-12-25T09:54:53.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/e4/5ebc1899d31d2b1601b32d21cfb4bba022ae6fce323d365f0448031b1660/typer-0.21.0-py3-none-any.whl", hash = "sha256:c79c01ca6b30af9fd48284058a7056ba0d3bf5cf10d0ff3d0c5b11b68c258ac6", size = 47109, upload-time = "2025-12-25T09:54:51.918Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Implements a comprehensive interactive simulator for testing LUI schemas
- Creates CLI interface with `lui-sim` command using typer and rich
- Adds conversation logging with save/load session functionality

### New Components

**Core Simulator (`src/lui_simulator/`)**
- `simulator.py`: LUISimulator class with intent extraction and response generation
- `context.py`: SimulatorContext for state, SimulatorConfig for settings
- `logger.py`: ConversationLogger with structured entry types
- `cli.py`: Typer CLI with simulate, info, and validate commands

**Example Schema**
- `examples/task_manager_schema.json`: Sample task manager LUI schema with 7 components

### CLI Usage

```bash
# Run interactive simulation
lui-sim simulate examples/task_manager_schema.json --tone friendly --formality neutral

# View schema info
lui-sim info examples/task_manager_schema.json

# Validate schema
lui-sim validate examples/task_manager_schema.json
```

### Interactive Commands

| Command | Description |
|---------|-------------|
| `quit` | Exit the simulator |
| `debug` | Show debug information |
| `reset` | Clear conversation and reset state |
| `transcript` | Show conversation transcript |
| `components` | List available components |
| `save` | Save session to file |
| `help` | Show help message |

## Test plan

- [x] Run all 139 tests (25 new simulator tests + existing tests)
- [x] Verify pyright passes with 0 errors
- [ ] Test CLI commands with example schema
- [ ] Verify session save/load works correctly

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)