### PR TITLE
feat(export): add schema export and integration module (issue #9)

### DIFF
--- a/examples/integration/export_demo.py
+++ b/examples/integration/export_demo.py
@@ -1,0 +1,85 @@
+"""
+Integration example: Export LUI schemas to multiple formats.
+
+This example demonstrates how to use the lui_schema_export module to convert
+a LUI schema into OpenAPI, MCP tools, Markdown, and TypeScript formats.
+"""
+
+import json
+from pathlib import Path
+import sys
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from lui_simulator.simulator import load_schema_from_dict
+from lui_schema_export import (
+    export_to_openapi,
+    export_to_mcp_tools,
+    export_to_markdown,
+    export_to_typescript,
+)
+
+
+def main():
+    """Run the export demo."""
+    # Load the example schema
+    schema_path = Path(__file__).parent.parent / "task_manager_schema.json"
+
+    print(f"Loading schema from: {schema_path}")
+
+    with open(schema_path) as f:
+        schema_data = json.load(f)
+
+    schema = load_schema_from_dict(schema_data)
+    print(f"Loaded schema: {schema.name} (v{schema.version})")
+    print(f"Components: {len(schema.components)}")
+    print()
+
+    # Create output directory
+    output_dir = Path(__file__).parent / "output"
+    output_dir.mkdir(exist_ok=True)
+
+    # Export to OpenAPI
+    print("Exporting to OpenAPI...")
+    openapi_spec = export_to_openapi(
+        schema,
+        base_path="/api/v1",
+        server_url="https://api.taskmanager.example.com",
+    )
+    openapi_path = output_dir / "openapi.json"
+    with open(openapi_path, "w") as f:
+        json.dump(openapi_spec, f, indent=2)
+    print(f"  -> Saved to {openapi_path}")
+
+    # Export to MCP tools
+    print("Exporting to MCP tools...")
+    mcp_tools = export_to_mcp_tools(schema, tool_name_prefix="task_")
+    mcp_path = output_dir / "mcp_tools.json"
+    with open(mcp_path, "w") as f:
+        json.dump(mcp_tools, f, indent=2)
+    print(f"  -> Saved to {mcp_path}")
+
+    # Export to Markdown
+    print("Exporting to Markdown...")
+    markdown_doc = export_to_markdown(schema)
+    markdown_path = output_dir / "documentation.md"
+    with open(markdown_path, "w") as f:
+        f.write(markdown_doc)
+    print(f"  -> Saved to {markdown_path}")
+
+    # Export to TypeScript
+    print("Exporting to TypeScript...")
+    typescript_types = export_to_typescript(schema, namespace="TaskManager")
+    typescript_path = output_dir / "types.ts"
+    with open(typescript_path, "w") as f:
+        f.write(typescript_types)
+    print(f"  -> Saved to {typescript_path}")
+
+    print()
+    print("Export complete!")
+    print(f"All files saved to: {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/integration/mcp_server_example.py
+++ b/examples/integration/mcp_server_example.py
@@ -1,0 +1,170 @@
+"""
+Integration example: Create an MCP server from a LUI schema.
+
+This example shows how to generate MCP tool definitions and create
+a simple server implementation that can be used with Claude or other
+MCP-compatible clients.
+"""
+
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from lui_simulator.simulator import load_schema_from_dict
+from lui_schema_export import MCPToolsExporter
+
+
+def create_mcp_server_config(schema_path: str) -> dict[str, Any]:
+    """Create an MCP server configuration from a LUI schema.
+
+    This generates the server capabilities and tool definitions that
+    can be used to implement an MCP server.
+
+    Args:
+        schema_path: Path to the LUI schema JSON file
+
+    Returns:
+        MCP server configuration dictionary
+    """
+    # Load schema
+    with open(schema_path) as f:
+        schema_data = json.load(f)
+
+    schema = load_schema_from_dict(schema_data)
+
+    # Create exporter with custom settings
+    exporter = MCPToolsExporter(
+        include_annotations=True,
+        include_examples=True,
+        tool_name_prefix="",  # No prefix for cleaner names
+    )
+
+    # Export as full server capabilities
+    return exporter.export_as_server_capabilities(schema)
+
+
+def generate_tool_handlers_stub(schema_path: str) -> str:
+    """Generate Python stub code for tool handlers.
+
+    This creates a skeleton implementation that developers can fill in
+    with actual business logic.
+
+    Args:
+        schema_path: Path to the LUI schema JSON file
+
+    Returns:
+        Python code as a string
+    """
+    with open(schema_path) as f:
+        schema_data = json.load(f)
+
+    schema = load_schema_from_dict(schema_data)
+
+    lines = [
+        '"""',
+        f"MCP Tool Handlers for {schema.name}",
+        "",
+        "Auto-generated from LUI schema. Implement the TODO sections.",
+        '"""',
+        "",
+        "from typing import Any",
+        "",
+        "",
+        "class ToolHandlers:",
+        f'    """Handlers for {schema.name} tools."""',
+        "",
+    ]
+
+    for component in schema.components:
+        # Convert component_id to snake_case method name
+        method_name = component.component_id.replace("-", "_")
+
+        # Build method signature
+        params = ["self"]
+        for param in component.parameters:
+            param_name = param.name.replace("-", "_")
+            type_hint = _get_python_type(param.param_type.value)
+            if param.required:
+                params.append(f"{param_name}: {type_hint}")
+            else:
+                params.append(f"{param_name}: {type_hint} | None = None")
+
+        params_str = ", ".join(params)
+
+        lines.extend([
+            f"    def {method_name}({params_str}) -> dict[str, Any]:",
+            f'        """',
+            f"        {component.intent}",
+            f"        ",
+            f'        Invocation: "{component.invocation.primary_phrase}"',
+            f'        """',
+            f"        # TODO: Implement {component.intent}",
+            f"        return {{",
+            f'            "success": True,',
+            f'            "message": "{component.feedback.success_template}",',
+            f'            "data": None,',
+            f"        }}",
+            "",
+        ])
+
+    return "\n".join(lines)
+
+
+def _get_python_type(param_type: str) -> str:
+    """Convert LUI parameter type to Python type hint."""
+    type_map = {
+        "STRING": "str",
+        "NUMBER": "float",
+        "BOOLEAN": "bool",
+        "DATE": "str",
+        "ENUM": "str",
+        "ENTITY": "str",
+        "LIST": "list[str]",
+    }
+    return type_map.get(param_type, "Any")
+
+
+def main():
+    """Run the MCP server example."""
+    schema_path = Path(__file__).parent.parent / "task_manager_schema.json"
+
+    print(f"Creating MCP server config from: {schema_path}")
+    print()
+
+    # Generate server config
+    config = create_mcp_server_config(str(schema_path))
+
+    print("Server Info:")
+    print(f"  Name: {config['serverInfo']['name']}")
+    print(f"  Version: {config['serverInfo']['version']}")
+    print(f"  Protocol: {config['protocolVersion']}")
+    print()
+
+    print(f"Tools ({len(config['tools'])}):")
+    for tool in config["tools"]:
+        print(f"  - {tool['name']}: {tool['description'].split(chr(10))[0]}")
+    print()
+
+    # Save config
+    output_dir = Path(__file__).parent / "output"
+    output_dir.mkdir(exist_ok=True)
+
+    config_path = output_dir / "mcp_server_config.json"
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+    print(f"Server config saved to: {config_path}")
+
+    # Generate handler stubs
+    handlers_code = generate_tool_handlers_stub(str(schema_path))
+    handlers_path = output_dir / "tool_handlers.py"
+    with open(handlers_path, "w") as f:
+        f.write(handlers_code)
+    print(f"Handler stubs saved to: {handlers_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/integration/openapi_client_example.py
+++ b/examples/integration/openapi_client_example.py
@@ -1,0 +1,203 @@
+"""
+Integration example: Generate an API client from LUI schema's OpenAPI export.
+
+This example demonstrates how to use the OpenAPI export to create
+type-safe API client code that can be used to interact with a LUI-based
+service.
+"""
+
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from lui_simulator.simulator import load_schema_from_dict
+from lui_schema_export import OpenAPIExporter
+
+
+def generate_python_client(schema_path: str) -> str:
+    """Generate a Python API client from a LUI schema.
+
+    Args:
+        schema_path: Path to the LUI schema JSON file
+
+    Returns:
+        Python code for an API client
+    """
+    with open(schema_path) as f:
+        schema_data = json.load(f)
+
+    schema = load_schema_from_dict(schema_data)
+
+    # Get the OpenAPI spec
+    exporter = OpenAPIExporter(
+        base_path="/api/v1",
+        server_url="https://api.example.com",
+    )
+    openapi_spec = exporter.export(schema)
+
+    # Generate client code
+    lines = [
+        '"""',
+        f"Python API Client for {schema.name}",
+        "",
+        f"Version: {schema.version}",
+        "Auto-generated from LUI schema.",
+        '"""',
+        "",
+        "import httpx",
+        "from dataclasses import dataclass",
+        "from typing import Any",
+        "",
+        "",
+        "@dataclass",
+        "class APIResponse:",
+        '    """Standard API response."""',
+        "    success: bool",
+        "    message: str",
+        "    data: Any | None = None",
+        "",
+        "",
+        f"class {_to_class_name(schema.name)}Client:",
+        f'    """API client for {schema.name}."""',
+        "",
+        f'    def __init__(self, base_url: str = "{openapi_spec["servers"][0]["url"]}"):'
+        "",
+        "        self.base_url = base_url.rstrip('/')",
+        "        self.client = httpx.Client()",
+        "",
+        "    def close(self):",
+        '        """Close the HTTP client."""',
+        "        self.client.close()",
+        "",
+        "    def __enter__(self):",
+        "        return self",
+        "",
+        "    def __exit__(self, *args):",
+        "        self.close()",
+        "",
+    ]
+
+    # Generate methods for each component
+    for component in schema.components:
+        method_name = component.component_id.replace("-", "_")
+        endpoint = f"/api/v1/{component.component_id}"
+
+        # Build method parameters
+        params = ["self"]
+        param_docs = []
+
+        for param in component.parameters:
+            param_name = param.name.replace("-", "_")
+            type_hint = _get_type_hint(param.param_type.value)
+
+            if param.required:
+                params.append(f"{param_name}: {type_hint}")
+            else:
+                params.append(f"{param_name}: {type_hint} | None = None")
+
+            param_docs.append(f"            {param_name}: {param.description}")
+
+        params_str = ", ".join(params)
+
+        # Build request body
+        body_items = []
+        for param in component.parameters:
+            param_name = param.name.replace("-", "_")
+            body_items.append(f'"{param.name}": {param_name}')
+        body_str = ", ".join(body_items) if body_items else ""
+
+        lines.extend([
+            f"    def {method_name}({params_str}) -> APIResponse:",
+            f'        """',
+            f"        {component.intent}",
+            f"        ",
+            f'        Invoke by saying: "{component.invocation.primary_phrase}"',
+        ])
+
+        if param_docs:
+            lines.append("        ")
+            lines.append("        Args:")
+            lines.extend(param_docs)
+
+        lines.extend([
+            f'        """',
+        ])
+
+        if body_items:
+            lines.append(f"        data = {{{body_str}}}")
+            lines.append(f"        # Remove None values")
+            lines.append(f"        data = {{k: v for k, v in data.items() if v is not None}}")
+            lines.append(f"        response = self.client.post(f\"{{self.base_url}}{endpoint}\", json=data)")
+        else:
+            lines.append(f"        response = self.client.post(f\"{{self.base_url}}{endpoint}\")")
+
+        lines.extend([
+            f"        response.raise_for_status()",
+            f"        result = response.json()",
+            f"        return APIResponse(",
+            f"            success=result.get('success', True),",
+            f"            message=result.get('message', ''),",
+            f"            data=result.get('data'),",
+            f"        )",
+            "",
+        ])
+
+    return "\n".join(lines)
+
+
+def _to_class_name(name: str) -> str:
+    """Convert a name to a valid Python class name."""
+    # Remove special characters and convert to PascalCase
+    words = name.replace("-", " ").replace("_", " ").split()
+    return "".join(word.capitalize() for word in words)
+
+
+def _get_type_hint(param_type: str) -> str:
+    """Get Python type hint for a parameter type."""
+    type_map = {
+        "STRING": "str",
+        "NUMBER": "float",
+        "BOOLEAN": "bool",
+        "DATE": "str",
+        "ENUM": "str",
+        "ENTITY": "str",
+        "LIST": "list[str]",
+    }
+    return type_map.get(param_type, "Any")
+
+
+def main():
+    """Run the OpenAPI client example."""
+    schema_path = Path(__file__).parent.parent / "task_manager_schema.json"
+
+    print(f"Generating Python API client from: {schema_path}")
+    print()
+
+    # Generate client code
+    client_code = generate_python_client(str(schema_path))
+
+    # Save to file
+    output_dir = Path(__file__).parent / "output"
+    output_dir.mkdir(exist_ok=True)
+
+    client_path = output_dir / "api_client.py"
+    with open(client_path, "w") as f:
+        f.write(client_code)
+
+    print(f"Client saved to: {client_path}")
+    print()
+    print("Usage example:")
+    print()
+    print("    from api_client import TaskManagerLuiClient")
+    print()
+    print("    with TaskManagerLuiClient() as client:")
+    print('        result = client.create_task(title="Review PR")')
+    print("        print(result.message)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lui_schema_export/__init__.py
+++ b/src/lui_schema_export/__init__.py
@@ -1,0 +1,17 @@
+"""LUI Schema Export - Export LUI schemas to various formats."""
+
+from .openapi import export_to_openapi, OpenAPIExporter
+from .mcp_tools import export_to_mcp_tools, MCPToolsExporter
+from .markdown import export_to_markdown, MarkdownExporter
+from .typescript import export_to_typescript, TypeScriptExporter
+
+__all__ = [
+    "export_to_openapi",
+    "OpenAPIExporter",
+    "export_to_mcp_tools",
+    "MCPToolsExporter",
+    "export_to_markdown",
+    "MarkdownExporter",
+    "export_to_typescript",
+    "TypeScriptExporter",
+]

--- a/src/lui_schema_export/markdown.py
+++ b/src/lui_schema_export/markdown.py
@@ -1,0 +1,204 @@
+"""Markdown documentation exporter for LUI schemas."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from baml_client.types import (
+    InterfaceSchema,
+    LUIComponent,
+    LUIComponentType,
+    ComponentParameter,
+)
+
+
+@dataclass
+class MarkdownExporter:
+    """Exports LUI schemas to Markdown documentation."""
+
+    include_toc: bool = True
+    include_examples: bool = True
+    include_parameters: bool = True
+    include_feedback: bool = True
+    heading_level: int = 1
+
+    def export(self, schema: InterfaceSchema) -> str:
+        """Export the schema to Markdown format."""
+        lines: list[str] = []
+        h = "#" * self.heading_level
+
+        # Title and description
+        lines.append(f"{h} {schema.name}\n")
+        lines.append(f"{schema.description}\n")
+
+        # Metadata
+        lines.append(f"**Version:** {schema.version}\n")
+
+        # Domain info
+        if schema.domain:
+            lines.append(f"{h}# Domain Information\n")
+            lines.append(f"- **Domain:** {schema.domain.domain_name}")
+            if schema.domain.subdomain:
+                lines.append(f"- **Subdomain:** {schema.domain.subdomain}")
+            lines.append(f"- **Description:** {schema.domain.description}")
+            if schema.domain.key_concepts:
+                concepts = ", ".join(schema.domain.key_concepts)
+                lines.append(f"- **Key Concepts:** {concepts}")
+            lines.append("")
+
+        # Table of contents
+        if self.include_toc and schema.components:
+            lines.append(f"{h}# Table of Contents\n")
+            for component in schema.components:
+                anchor = component.component_id.lower().replace(" ", "-")
+                lines.append(f"- [{component.intent}](#{anchor})")
+            lines.append("")
+
+        # Components by type
+        components_by_type = self._group_by_type(schema.components)
+
+        lines.append(f"{h}# Available Commands\n")
+
+        for comp_type, components in components_by_type.items():
+            lines.append(f"{h}## {comp_type.value.title()} Commands\n")
+
+            for component in components:
+                lines.extend(self._render_component(component))
+
+        # Entities if available
+        if schema.entities:
+            lines.append(f"{h}# Domain Entities\n")
+            for entity in schema.entities:
+                lines.append(f"{h}## {entity.entity_name}\n")
+                lines.append(f"{entity.description}\n")
+                if entity.attributes:
+                    lines.append("| Attribute | Type | Description |")
+                    lines.append("|-----------|------|-------------|")
+                    for attr in entity.attributes:
+                        lines.append(f"| {attr.attribute_name} | {attr.attribute_type.value} | {attr.description} |")
+                    lines.append("")
+
+        # Flows if available
+        if schema.flows:
+            lines.append(f"{h}# Conversational Flows\n")
+            for flow in schema.flows:
+                lines.append(f"{h}## {flow.name}\n")
+                if flow.description:
+                    lines.append(f"{flow.description}\n")
+                if flow.steps:
+                    lines.append("**Steps:**\n")
+                    for i, step in enumerate(flow.steps, 1):
+                        step_desc = step.prompt_template or step.component_ref or step.step_type.value
+                        lines.append(f"{i}. {step.step_id}: {step_desc}")
+                    lines.append("")
+
+        return "\n".join(lines)
+
+    def _group_by_type(
+        self,
+        components: list[LUIComponent],
+    ) -> dict[LUIComponentType, list[LUIComponent]]:
+        """Group components by their type."""
+        groups: dict[LUIComponentType, list[LUIComponent]] = {}
+        for component in components:
+            if component.component_type not in groups:
+                groups[component.component_type] = []
+            groups[component.component_type].append(component)
+        return groups
+
+    def _render_component(self, component: LUIComponent) -> list[str]:
+        """Render a single component to Markdown."""
+        h = "#" * (self.heading_level + 2)
+        lines: list[str] = []
+
+        # Component header with anchor
+        lines.append(f"<a id=\"{component.component_id.lower()}\"></a>")
+        lines.append(f"{h} {component.intent}\n")
+
+        # Invocation
+        lines.append(f"**Say:** \"{component.invocation.primary_phrase}\"\n")
+
+        if component.invocation.alternate_phrases:
+            phrases = ", ".join(f'"{p}"' for p in component.invocation.alternate_phrases)
+            lines.append(f"**Also works with:** {phrases}\n")
+
+        # Examples
+        if self.include_examples and component.invocation.examples:
+            lines.append("**Examples:**\n")
+            for example in component.invocation.examples:
+                lines.append(f"- \"{example}\"")
+            lines.append("")
+
+        # Parameters
+        if self.include_parameters and component.parameters:
+            lines.append("**Parameters:**\n")
+            lines.append("| Name | Type | Required | Description |")
+            lines.append("|------|------|----------|-------------|")
+            for param in component.parameters:
+                required = "Yes" if param.required else "No"
+                lines.append(f"| `{param.name}` | {param.param_type.value} | {required} | {param.description} |")
+            lines.append("")
+
+        # Feedback templates
+        if self.include_feedback:
+            lines.append("**Responses:**\n")
+            lines.append(f"- ✅ Success: \"{component.feedback.success_template}\"")
+            lines.append(f"- ❌ Error: \"{component.feedback.error_template}\"")
+            if component.feedback.confirmation_required:
+                prompt = component.feedback.confirmation_prompt or "Are you sure?"
+                lines.append(f"- ⚠️ Confirmation: \"{prompt}\"")
+            lines.append("")
+
+        lines.append("---\n")
+
+        return lines
+
+    def export_quick_reference(self, schema: InterfaceSchema) -> str:
+        """Export a quick reference card in Markdown format."""
+        lines: list[str] = []
+        h = "#" * self.heading_level
+
+        lines.append(f"{h} {schema.name} - Quick Reference\n")
+
+        # Commands table
+        lines.append("| Command | What to say | Type |")
+        lines.append("|---------|-------------|------|")
+
+        for component in schema.components:
+            lines.append(
+                f"| {component.intent} | "
+                f"\"{component.invocation.primary_phrase}\" | "
+                f"{component.component_type.value} |"
+            )
+
+        lines.append("")
+
+        # Key concepts
+        if schema.domain and schema.domain.key_concepts:
+            lines.append(f"{h}# Key Concepts\n")
+            for concept in schema.domain.key_concepts:
+                lines.append(f"- {concept}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+
+def export_to_markdown(
+    schema: InterfaceSchema,
+    include_toc: bool = True,
+    include_examples: bool = True,
+) -> str:
+    """Export a LUI schema to Markdown documentation.
+
+    Args:
+        schema: The LUI interface schema to export
+        include_toc: Whether to include table of contents (default: True)
+        include_examples: Whether to include invocation examples (default: True)
+
+    Returns:
+        A Markdown formatted string
+    """
+    exporter = MarkdownExporter(
+        include_toc=include_toc,
+        include_examples=include_examples,
+    )
+    return exporter.export(schema)

--- a/src/lui_schema_export/mcp_tools.py
+++ b/src/lui_schema_export/mcp_tools.py
@@ -1,0 +1,184 @@
+"""MCP (Model Context Protocol) tools exporter for LUI schemas."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from baml_client.types import (
+    InterfaceSchema,
+    LUIComponent,
+    ParameterType,
+    ComponentParameter,
+)
+
+
+def param_type_to_json_type(param_type: ParameterType) -> str:
+    """Convert a LUI parameter type to JSON Schema type string."""
+    type_mapping = {
+        ParameterType.STRING: "string",
+        ParameterType.NUMBER: "number",
+        ParameterType.BOOLEAN: "boolean",
+        ParameterType.DATE: "string",
+        ParameterType.ENUM: "string",
+        ParameterType.ENTITY: "string",
+        ParameterType.LIST: "array",
+    }
+    return type_mapping.get(param_type, "string")
+
+
+def build_mcp_property(param: ComponentParameter) -> dict[str, Any]:
+    """Build an MCP tool property from a component parameter."""
+    prop: dict[str, Any] = {
+        "type": param_type_to_json_type(param.param_type),
+        "description": param.description,
+    }
+
+    # Handle array type
+    if param.param_type == ParameterType.LIST:
+        prop["items"] = {"type": "string"}
+
+    # Add format for date
+    if param.param_type == ParameterType.DATE:
+        prop["format"] = "date-time"
+
+    # Add default value
+    if param.default_value is not None:
+        prop["default"] = param.default_value
+
+    return prop
+
+
+@dataclass
+class MCPToolsExporter:
+    """Exports LUI schemas to MCP tool definitions."""
+
+    include_annotations: bool = True
+    include_examples: bool = True
+    tool_name_prefix: str = ""
+
+    def export(self, schema: InterfaceSchema) -> list[dict[str, Any]]:
+        """Export the schema to MCP tool definitions."""
+        tools = []
+
+        for component in schema.components:
+            tool = self._build_tool(component, schema)
+            tools.append(tool)
+
+        return tools
+
+    def _build_tool(
+        self,
+        component: LUIComponent,
+        schema: InterfaceSchema,
+    ) -> dict[str, Any]:
+        """Build an MCP tool definition for a component."""
+        tool_name = f"{self.tool_name_prefix}{component.component_id}"
+
+        # Build input schema
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+
+        for param in component.parameters:
+            properties[param.name] = build_mcp_property(param)
+            if param.required:
+                required.append(param.name)
+
+        input_schema: dict[str, Any] = {
+            "type": "object",
+            "properties": properties,
+        }
+
+        if required:
+            input_schema["required"] = required
+
+        tool: dict[str, Any] = {
+            "name": tool_name,
+            "description": self._build_description(component),
+            "inputSchema": input_schema,
+        }
+
+        # Add annotations if enabled
+        if self.include_annotations:
+            tool["annotations"] = self._build_annotations(component, schema)
+
+        return tool
+
+    def _build_description(self, component: LUIComponent) -> str:
+        """Build a description for the MCP tool."""
+        lines = [component.intent]
+
+        lines.append(f"\nInvoke with: \"{component.invocation.primary_phrase}\"")
+
+        if component.invocation.alternate_phrases:
+            alt = ", ".join(f'"{p}"' for p in component.invocation.alternate_phrases[:3])
+            lines.append(f"Also: {alt}")
+
+        if self.include_examples and component.invocation.examples:
+            lines.append("\nExamples:")
+            for example in component.invocation.examples[:3]:
+                lines.append(f"  - {example}")
+
+        return "\n".join(lines)
+
+    def _build_annotations(
+        self,
+        component: LUIComponent,
+        schema: InterfaceSchema,
+    ) -> dict[str, Any]:
+        """Build MCP annotations for the tool."""
+        annotations: dict[str, Any] = {
+            "component_type": component.component_type.value,
+            "domain": schema.domain.domain_name if schema.domain else None,
+            "confirmation_required": component.feedback.confirmation_required,
+        }
+
+        # Add accessibility info if available
+        if component.accessibility:
+            annotations["accessibility"] = {
+                "screen_reader_label": component.accessibility.screen_reader_label,
+                "keyboard_shortcut": component.accessibility.keyboard_shortcut,
+            }
+
+        return annotations
+
+    def export_as_server_capabilities(
+        self,
+        schema: InterfaceSchema,
+    ) -> dict[str, Any]:
+        """Export as MCP server capabilities format."""
+        tools = self.export(schema)
+
+        return {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {
+                "tools": {
+                    "listChanged": True,
+                }
+            },
+            "serverInfo": {
+                "name": schema.name,
+                "version": schema.version,
+            },
+            "tools": tools,
+        }
+
+
+def export_to_mcp_tools(
+    schema: InterfaceSchema,
+    include_annotations: bool = True,
+    tool_name_prefix: str = "",
+) -> list[dict[str, Any]]:
+    """Export a LUI schema to MCP tool definitions.
+
+    Args:
+        schema: The LUI interface schema to export
+        include_annotations: Whether to include MCP annotations (default: True)
+        tool_name_prefix: Prefix to add to tool names (default: "")
+
+    Returns:
+        A list of MCP tool definitions
+    """
+    exporter = MCPToolsExporter(
+        include_annotations=include_annotations,
+        tool_name_prefix=tool_name_prefix,
+    )
+    return exporter.export(schema)

--- a/src/lui_schema_export/openapi.py
+++ b/src/lui_schema_export/openapi.py
@@ -1,0 +1,226 @@
+"""OpenAPI exporter for LUI schemas."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from baml_client.types import (
+    InterfaceSchema,
+    LUIComponent,
+    ParameterType,
+    ComponentParameter,
+)
+
+
+def param_type_to_json_schema(param_type: ParameterType) -> dict[str, Any]:
+    """Convert a LUI parameter type to JSON Schema type."""
+    type_mapping = {
+        ParameterType.STRING: {"type": "string"},
+        ParameterType.NUMBER: {"type": "number"},
+        ParameterType.BOOLEAN: {"type": "boolean"},
+        ParameterType.DATE: {"type": "string", "format": "date-time"},
+        ParameterType.ENUM: {"type": "string"},
+        ParameterType.ENTITY: {"type": "string"},
+        ParameterType.LIST: {"type": "array", "items": {"type": "string"}},
+    }
+    return type_mapping.get(param_type, {"type": "string"})
+
+
+def build_parameter_schema(param: ComponentParameter) -> dict[str, Any]:
+    """Build a JSON Schema for a component parameter."""
+    schema = param_type_to_json_schema(param.param_type)
+    schema["description"] = param.description
+
+    if param.default_value is not None:
+        schema["default"] = param.default_value
+
+    # Add extraction hints as examples
+    if param.extraction_hints:
+        schema["examples"] = param.extraction_hints
+
+    return schema
+
+
+@dataclass
+class OpenAPIExporter:
+    """Exports LUI schemas to OpenAPI 3.0 specification."""
+
+    base_path: str = "/actions"
+    include_examples: bool = True
+    include_feedback_templates: bool = True
+    server_url: str = field(default="http://localhost:8000")
+
+    def export(self, schema: InterfaceSchema) -> dict[str, Any]:
+        """Export the schema to OpenAPI format."""
+        paths = {}
+        tags = []
+
+        # Group components by type for tags
+        component_types = set()
+        for component in schema.components:
+            component_types.add(component.component_type.value)
+
+        for comp_type in sorted(component_types):
+            tags.append({
+                "name": comp_type.lower(),
+                "description": f"{comp_type} components",
+            })
+
+        # Build paths for each component
+        for component in schema.components:
+            path = f"{self.base_path}/{component.component_id}"
+            paths[path] = self._build_path_item(component)
+
+        # Build the full OpenAPI spec
+        spec: dict[str, Any] = {
+            "openapi": "3.0.3",
+            "info": {
+                "title": schema.name,
+                "description": schema.description,
+                "version": schema.version,
+            },
+            "servers": [{"url": self.server_url}],
+            "tags": tags,
+            "paths": paths,
+        }
+
+        # Add domain info as extension
+        if schema.domain:
+            spec["info"]["x-domain"] = {
+                "name": schema.domain.domain_name,
+                "subdomain": schema.domain.subdomain,
+                "description": schema.domain.description,
+                "key_concepts": schema.domain.key_concepts,
+            }
+
+        return spec
+
+    def _build_path_item(self, component: LUIComponent) -> dict[str, Any]:
+        """Build an OpenAPI path item for a component."""
+        operation: dict[str, Any] = {
+            "operationId": component.component_id,
+            "summary": component.intent,
+            "description": self._build_description(component),
+            "tags": [component.component_type.value.lower()],
+        }
+
+        # Build request body if there are parameters
+        if component.parameters:
+            properties = {}
+            required = []
+
+            for param in component.parameters:
+                properties[param.name] = build_parameter_schema(param)
+                if param.required:
+                    required.append(param.name)
+
+            operation["requestBody"] = {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": properties,
+                            "required": required if required else None,
+                        }
+                    }
+                }
+            }
+
+        # Build responses
+        operation["responses"] = self._build_responses(component)
+
+        return {"post": operation}
+
+    def _build_description(self, component: LUIComponent) -> str:
+        """Build a detailed description for the component."""
+        lines = []
+
+        lines.append(f"**Primary Invocation:** {component.invocation.primary_phrase}")
+
+        if component.invocation.alternate_phrases:
+            lines.append(f"\n**Alternate Phrases:** {', '.join(component.invocation.alternate_phrases)}")
+
+        if self.include_examples and component.invocation.examples:
+            lines.append("\n**Examples:**")
+            for example in component.invocation.examples:
+                lines.append(f"- {example}")
+
+        return "\n".join(lines)
+
+    def _build_responses(self, component: LUIComponent) -> dict[str, Any]:
+        """Build response definitions for the component."""
+        responses: dict[str, Any] = {
+            "200": {
+                "description": "Successful execution",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "success": {"type": "boolean"},
+                                "message": {"type": "string"},
+                                "data": {"type": "object"},
+                            }
+                        }
+                    }
+                }
+            },
+            "400": {
+                "description": "Invalid parameters or request",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {"type": "string"},
+                                "details": {"type": "object"},
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if self.include_feedback_templates:
+            responses["200"]["x-success-template"] = component.feedback.success_template
+            responses["400"]["x-error-template"] = component.feedback.error_template
+
+        # Add confirmation response if required
+        if component.feedback.confirmation_required:
+            responses["202"] = {
+                "description": "Confirmation required",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "requires_confirmation": {"type": "boolean"},
+                                "confirmation_prompt": {"type": "string"},
+                            }
+                        }
+                    }
+                }
+            }
+            if component.feedback.confirmation_prompt:
+                responses["202"]["x-confirmation-prompt"] = component.feedback.confirmation_prompt
+
+        return responses
+
+
+def export_to_openapi(
+    schema: InterfaceSchema,
+    base_path: str = "/actions",
+    server_url: str = "http://localhost:8000",
+) -> dict[str, Any]:
+    """Export a LUI schema to OpenAPI 3.0 specification.
+
+    Args:
+        schema: The LUI interface schema to export
+        base_path: Base path for all operations (default: /actions)
+        server_url: Server URL for the API (default: http://localhost:8000)
+
+    Returns:
+        A dictionary containing the OpenAPI specification
+    """
+    exporter = OpenAPIExporter(base_path=base_path, server_url=server_url)
+    return exporter.export(schema)

--- a/src/lui_schema_export/typescript.py
+++ b/src/lui_schema_export/typescript.py
@@ -1,0 +1,284 @@
+"""TypeScript types exporter for LUI schemas."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from baml_client.types import (
+    InterfaceSchema,
+    LUIComponent,
+    ParameterType,
+    ComponentParameter,
+    LUIComponentType,
+)
+
+
+def param_type_to_ts_type(param_type: ParameterType) -> str:
+    """Convert a LUI parameter type to TypeScript type."""
+    type_mapping = {
+        ParameterType.STRING: "string",
+        ParameterType.NUMBER: "number",
+        ParameterType.BOOLEAN: "boolean",
+        ParameterType.DATE: "Date",
+        ParameterType.ENUM: "string",
+        ParameterType.ENTITY: "string",
+        ParameterType.LIST: "string[]",
+    }
+    return type_mapping.get(param_type, "unknown")
+
+
+def to_pascal_case(s: str) -> str:
+    """Convert a string to PascalCase."""
+    parts = s.replace("-", "_").split("_")
+    return "".join(word.capitalize() for word in parts)
+
+
+def to_camel_case(s: str) -> str:
+    """Convert a string to camelCase."""
+    pascal = to_pascal_case(s)
+    return pascal[0].lower() + pascal[1:] if pascal else ""
+
+
+@dataclass
+class TypeScriptExporter:
+    """Exports LUI schemas to TypeScript type definitions."""
+
+    include_jsdoc: bool = True
+    include_enums: bool = True
+    namespace: str | None = None
+    export_style: str = "interface"  # "interface" or "type"
+
+    def export(self, schema: InterfaceSchema) -> str:
+        """Export the schema to TypeScript type definitions."""
+        lines: list[str] = []
+
+        # Header comment
+        lines.append("/**")
+        lines.append(f" * {schema.name}")
+        lines.append(f" * {schema.description}")
+        lines.append(f" * Version: {schema.version}")
+        lines.append(" * ")
+        lines.append(" * Auto-generated from LUI schema. Do not edit manually.")
+        lines.append(" */")
+        lines.append("")
+
+        # Enums
+        if self.include_enums:
+            lines.extend(self._generate_enums())
+            lines.append("")
+
+        # Start namespace if specified
+        if self.namespace:
+            lines.append(f"export namespace {self.namespace} {{")
+            indent = "  "
+        else:
+            indent = ""
+
+        # Component types
+        for component in schema.components:
+            lines.extend(self._generate_component_types(component, indent))
+            lines.append("")
+
+        # Main schema interface
+        lines.extend(self._generate_schema_interface(schema, indent))
+        lines.append("")
+
+        # Action dispatcher type
+        lines.extend(self._generate_action_types(schema, indent))
+
+        # Close namespace
+        if self.namespace:
+            lines.append("}")
+
+        return "\n".join(lines)
+
+    def _generate_enums(self) -> list[str]:
+        """Generate TypeScript enums for component types and parameter types."""
+        lines: list[str] = []
+
+        # Component type enum
+        lines.append("export enum LUIComponentType {")
+        for comp_type in LUIComponentType:
+            lines.append(f"  {comp_type.name} = '{comp_type.value}',")
+        lines.append("}")
+        lines.append("")
+
+        # Parameter type enum
+        lines.append("export enum ParameterType {")
+        for param_type in ParameterType:
+            lines.append(f"  {param_type.name} = '{param_type.value}',")
+        lines.append("}")
+
+        return lines
+
+    def _generate_component_types(
+        self,
+        component: LUIComponent,
+        indent: str,
+    ) -> list[str]:
+        """Generate TypeScript types for a component."""
+        lines: list[str] = []
+        type_name = to_pascal_case(component.component_id)
+
+        # Input params type
+        if component.parameters:
+            lines.extend(self._generate_params_interface(component, type_name, indent))
+            lines.append("")
+
+        # Result type
+        lines.extend(self._generate_result_interface(component, type_name, indent))
+
+        return lines
+
+    def _generate_params_interface(
+        self,
+        component: LUIComponent,
+        type_name: str,
+        indent: str,
+    ) -> list[str]:
+        """Generate TypeScript interface for component parameters."""
+        lines: list[str] = []
+
+        if self.include_jsdoc:
+            lines.append(f"{indent}/**")
+            lines.append(f"{indent} * Parameters for {component.intent}")
+            lines.append(f"{indent} */")
+
+        keyword = "interface" if self.export_style == "interface" else "type"
+        eq = "" if keyword == "interface" else " ="
+
+        lines.append(f"{indent}export {keyword} {type_name}Params{eq} {{")
+
+        for param in component.parameters:
+            if self.include_jsdoc:
+                lines.append(f"{indent}  /** {param.description} */")
+
+            optional = "" if param.required else "?"
+            ts_type = param_type_to_ts_type(param.param_type)
+            lines.append(f"{indent}  {to_camel_case(param.name)}{optional}: {ts_type};")
+
+        lines.append(f"{indent}}}")
+
+        return lines
+
+    def _generate_result_interface(
+        self,
+        component: LUIComponent,
+        type_name: str,
+        indent: str,
+    ) -> list[str]:
+        """Generate TypeScript interface for component result."""
+        lines: list[str] = []
+
+        if self.include_jsdoc:
+            lines.append(f"{indent}/**")
+            lines.append(f"{indent} * Result of {component.intent}")
+            lines.append(f"{indent} */")
+
+        keyword = "interface" if self.export_style == "interface" else "type"
+        eq = "" if keyword == "interface" else " ="
+
+        lines.append(f"{indent}export {keyword} {type_name}Result{eq} {{")
+        lines.append(f"{indent}  success: boolean;")
+        lines.append(f"{indent}  message: string;")
+        lines.append(f"{indent}  data?: unknown;")
+
+        if component.feedback.confirmation_required:
+            lines.append(f"{indent}  requiresConfirmation?: boolean;")
+            lines.append(f"{indent}  confirmationPrompt?: string;")
+
+        lines.append(f"{indent}}}")
+
+        return lines
+
+    def _generate_schema_interface(
+        self,
+        schema: InterfaceSchema,
+        indent: str,
+    ) -> list[str]:
+        """Generate the main schema interface."""
+        lines: list[str] = []
+        schema_name = to_pascal_case(schema.schema_id.replace("-", "_"))
+
+        if self.include_jsdoc:
+            lines.append(f"{indent}/**")
+            lines.append(f"{indent} * {schema.name} interface schema")
+            lines.append(f"{indent} * {schema.description}")
+            lines.append(f"{indent} */")
+
+        lines.append(f"{indent}export interface {schema_name}Schema {{")
+        lines.append(f"{indent}  schemaId: '{schema.schema_id}';")
+        lines.append(f"{indent}  name: '{schema.name}';")
+        lines.append(f"{indent}  version: '{schema.version}';")
+
+        # Component IDs
+        component_ids = [f"'{c.component_id}'" for c in schema.components]
+        lines.append(f"{indent}  componentIds: [{', '.join(component_ids)}];")
+
+        lines.append(f"{indent}}}")
+
+        return lines
+
+    def _generate_action_types(
+        self,
+        schema: InterfaceSchema,
+        indent: str,
+    ) -> list[str]:
+        """Generate action dispatcher types."""
+        lines: list[str] = []
+
+        if self.include_jsdoc:
+            lines.append(f"{indent}/**")
+            lines.append(f"{indent} * Union type for all action names")
+            lines.append(f"{indent} */")
+
+        action_names = [f"'{c.component_id}'" for c in schema.components]
+        lines.append(f"{indent}export type ActionName = {' | '.join(action_names)};")
+        lines.append("")
+
+        # Action handlers interface
+        if self.include_jsdoc:
+            lines.append(f"{indent}/**")
+            lines.append(f"{indent} * Action handler interface for implementing LUI actions")
+            lines.append(f"{indent} */")
+
+        lines.append(f"{indent}export interface ActionHandlers {{")
+
+        for component in schema.components:
+            type_name = to_pascal_case(component.component_id)
+            handler_name = to_camel_case(component.component_id)
+
+            if component.parameters:
+                lines.append(f"{indent}  {handler_name}(params: {type_name}Params): Promise<{type_name}Result>;")
+            else:
+                lines.append(f"{indent}  {handler_name}(): Promise<{type_name}Result>;")
+
+        lines.append(f"{indent}}}")
+
+        return lines
+
+    def export_declaration_file(self, schema: InterfaceSchema) -> str:
+        """Export as a .d.ts declaration file."""
+        content = self.export(schema)
+        return f"// Type definitions for {schema.name}\n// Project: LUI Schema Export\n\n{content}"
+
+
+def export_to_typescript(
+    schema: InterfaceSchema,
+    include_jsdoc: bool = True,
+    namespace: str | None = None,
+) -> str:
+    """Export a LUI schema to TypeScript type definitions.
+
+    Args:
+        schema: The LUI interface schema to export
+        include_jsdoc: Whether to include JSDoc comments (default: True)
+        namespace: Optional namespace to wrap types in
+
+    Returns:
+        A TypeScript type definitions string
+    """
+    exporter = TypeScriptExporter(
+        include_jsdoc=include_jsdoc,
+        namespace=namespace,
+    )
+    return exporter.export(schema)

--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -1,0 +1,569 @@
+"""Tests for LUI Schema Export module."""
+
+import json
+import pytest
+from pathlib import Path
+
+from baml_client.types import (
+    InterfaceSchema,
+    DomainInfo,
+    LUIComponent,
+    LUIComponentType,
+    InvocationPattern,
+    FeedbackConfig,
+    ComponentParameter,
+    ParameterType,
+)
+
+# Import exporters
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from lui_schema_export.openapi import (
+    export_to_openapi,
+    OpenAPIExporter,
+    param_type_to_json_schema,
+)
+from lui_schema_export.mcp_tools import (
+    export_to_mcp_tools,
+    MCPToolsExporter,
+    param_type_to_json_type,
+)
+from lui_schema_export.markdown import (
+    export_to_markdown,
+    MarkdownExporter,
+)
+from lui_schema_export.typescript import (
+    export_to_typescript,
+    TypeScriptExporter,
+    to_pascal_case,
+    to_camel_case,
+)
+
+
+# ============================================
+# Test Fixtures
+# ============================================
+
+@pytest.fixture
+def sample_parameter() -> ComponentParameter:
+    """Create a sample component parameter."""
+    return ComponentParameter(
+        name="task_title",
+        param_type=ParameterType.STRING,
+        description="The title of the task",
+        required=True,
+        default_value=None,
+        extraction_hints=["task called", "task named"],
+        validation=None,
+    )
+
+
+@pytest.fixture
+def sample_component(sample_parameter: ComponentParameter) -> LUIComponent:
+    """Create a sample LUI component."""
+    return LUIComponent(
+        component_id="create-task",
+        component_type=LUIComponentType.ACTION,
+        intent="Create a new task",
+        invocation=InvocationPattern(
+            primary_phrase="create task",
+            alternate_phrases=["add task", "new task"],
+            examples=["Create a task to review code", "Add task called finish report"],
+            context_requirements=None,
+        ),
+        parameters=[sample_parameter],
+        feedback=FeedbackConfig(
+            success_template="Task '{title}' created successfully",
+            error_template="Could not create task: {error}",
+            progress_template=None,
+            confirmation_required=False,
+            confirmation_prompt=None,
+        ),
+        accessibility=None,
+    )
+
+
+@pytest.fixture
+def sample_schema(sample_component: LUIComponent) -> InterfaceSchema:
+    """Create a sample interface schema."""
+    domain = DomainInfo(
+        domain_name="task-management",
+        subdomain="personal-productivity",
+        description="Task and project management",
+        key_concepts=["tasks", "projects", "deadlines"],
+        terminology=None,
+    )
+
+    query_component = LUIComponent(
+        component_id="list-tasks",
+        component_type=LUIComponentType.QUERY,
+        intent="List all tasks",
+        invocation=InvocationPattern(
+            primary_phrase="list tasks",
+            alternate_phrases=["show tasks", "my tasks"],
+            examples=["Show me my tasks"],
+            context_requirements=None,
+        ),
+        parameters=[],
+        feedback=FeedbackConfig(
+            success_template="Here are your tasks",
+            error_template="Could not list tasks",
+            progress_template=None,
+            confirmation_required=False,
+            confirmation_prompt=None,
+        ),
+        accessibility=None,
+    )
+
+    confirm_component = LUIComponent(
+        component_id="delete-task",
+        component_type=LUIComponentType.ACTION,
+        intent="Delete a task",
+        invocation=InvocationPattern(
+            primary_phrase="delete task",
+            alternate_phrases=["remove task"],
+            examples=["Delete task 123"],
+            context_requirements=None,
+        ),
+        parameters=[],
+        feedback=FeedbackConfig(
+            success_template="Task deleted",
+            error_template="Could not delete task",
+            progress_template=None,
+            confirmation_required=True,
+            confirmation_prompt="Are you sure you want to delete this task?",
+        ),
+        accessibility=None,
+    )
+
+    return InterfaceSchema(
+        schema_id="test-schema-v1",
+        name="Test Task Manager",
+        description="A test task management schema",
+        version="1.0.0",
+        domain=domain,
+        components=[sample_component, query_component, confirm_component],
+        flows=[],
+        entities=[],
+        global_context=None,
+    )
+
+
+# ============================================
+# Test OpenAPI Exporter
+# ============================================
+
+class TestOpenAPIExporter:
+    """Test OpenAPI export functionality."""
+
+    def test_param_type_to_json_schema_string(self):
+        """Test string parameter type conversion."""
+        result = param_type_to_json_schema(ParameterType.STRING)
+        assert result == {"type": "string"}
+
+    def test_param_type_to_json_schema_number(self):
+        """Test number parameter type conversion."""
+        result = param_type_to_json_schema(ParameterType.NUMBER)
+        assert result == {"type": "number"}
+
+    def test_param_type_to_json_schema_boolean(self):
+        """Test boolean parameter type conversion."""
+        result = param_type_to_json_schema(ParameterType.BOOLEAN)
+        assert result == {"type": "boolean"}
+
+    def test_param_type_to_json_schema_date(self):
+        """Test date parameter type conversion."""
+        result = param_type_to_json_schema(ParameterType.DATE)
+        assert result == {"type": "string", "format": "date-time"}
+
+    def test_param_type_to_json_schema_list(self):
+        """Test list parameter type conversion."""
+        result = param_type_to_json_schema(ParameterType.LIST)
+        assert result == {"type": "array", "items": {"type": "string"}}
+
+    def test_export_basic_structure(self, sample_schema: InterfaceSchema):
+        """Test that export creates valid OpenAPI structure."""
+        result = export_to_openapi(sample_schema)
+
+        assert result["openapi"] == "3.0.3"
+        assert "info" in result
+        assert "paths" in result
+        assert "tags" in result
+
+    def test_export_info_section(self, sample_schema: InterfaceSchema):
+        """Test that info section is populated correctly."""
+        result = export_to_openapi(sample_schema)
+
+        assert result["info"]["title"] == "Test Task Manager"
+        assert result["info"]["description"] == "A test task management schema"
+        assert result["info"]["version"] == "1.0.0"
+
+    def test_export_domain_info(self, sample_schema: InterfaceSchema):
+        """Test that domain info is included as extension."""
+        result = export_to_openapi(sample_schema)
+
+        assert "x-domain" in result["info"]
+        assert result["info"]["x-domain"]["name"] == "task-management"
+
+    def test_export_paths_for_components(self, sample_schema: InterfaceSchema):
+        """Test that paths are created for each component."""
+        result = export_to_openapi(sample_schema)
+
+        assert "/actions/create-task" in result["paths"]
+        assert "/actions/list-tasks" in result["paths"]
+        assert "/actions/delete-task" in result["paths"]
+
+    def test_export_custom_base_path(self, sample_schema: InterfaceSchema):
+        """Test custom base path."""
+        result = export_to_openapi(sample_schema, base_path="/api/v1")
+
+        assert "/api/v1/create-task" in result["paths"]
+
+    def test_export_server_url(self, sample_schema: InterfaceSchema):
+        """Test server URL configuration."""
+        result = export_to_openapi(
+            sample_schema,
+            server_url="https://api.example.com",
+        )
+
+        assert result["servers"][0]["url"] == "https://api.example.com"
+
+    def test_export_request_body_for_params(self, sample_schema: InterfaceSchema):
+        """Test that request body is created for components with parameters."""
+        result = export_to_openapi(sample_schema)
+        create_task = result["paths"]["/actions/create-task"]["post"]
+
+        assert "requestBody" in create_task
+        schema = create_task["requestBody"]["content"]["application/json"]["schema"]
+        assert "task_title" in schema["properties"]
+
+    def test_export_confirmation_response(self, sample_schema: InterfaceSchema):
+        """Test confirmation response for components requiring confirmation."""
+        result = export_to_openapi(sample_schema)
+        delete_task = result["paths"]["/actions/delete-task"]["post"]
+
+        assert "202" in delete_task["responses"]
+        assert "x-confirmation-prompt" in delete_task["responses"]["202"]
+
+    def test_exporter_class(self, sample_schema: InterfaceSchema):
+        """Test OpenAPIExporter class directly."""
+        exporter = OpenAPIExporter(
+            base_path="/custom",
+            include_examples=True,
+            server_url="http://localhost:3000",
+        )
+        result = exporter.export(sample_schema)
+
+        assert "/custom/create-task" in result["paths"]
+        assert result["servers"][0]["url"] == "http://localhost:3000"
+
+
+# ============================================
+# Test MCP Tools Exporter
+# ============================================
+
+class TestMCPToolsExporter:
+    """Test MCP tools export functionality."""
+
+    def test_param_type_to_json_type(self):
+        """Test parameter type to JSON type conversion."""
+        assert param_type_to_json_type(ParameterType.STRING) == "string"
+        assert param_type_to_json_type(ParameterType.NUMBER) == "number"
+        assert param_type_to_json_type(ParameterType.BOOLEAN) == "boolean"
+        assert param_type_to_json_type(ParameterType.LIST) == "array"
+
+    def test_export_returns_list(self, sample_schema: InterfaceSchema):
+        """Test that export returns a list of tools."""
+        result = export_to_mcp_tools(sample_schema)
+
+        assert isinstance(result, list)
+        assert len(result) == 3
+
+    def test_export_tool_structure(self, sample_schema: InterfaceSchema):
+        """Test that each tool has required MCP fields."""
+        result = export_to_mcp_tools(sample_schema)
+
+        for tool in result:
+            assert "name" in tool
+            assert "description" in tool
+            assert "inputSchema" in tool
+
+    def test_export_tool_names(self, sample_schema: InterfaceSchema):
+        """Test that tool names match component IDs."""
+        result = export_to_mcp_tools(sample_schema)
+        names = [t["name"] for t in result]
+
+        assert "create-task" in names
+        assert "list-tasks" in names
+        assert "delete-task" in names
+
+    def test_export_with_prefix(self, sample_schema: InterfaceSchema):
+        """Test tool name prefix."""
+        result = export_to_mcp_tools(sample_schema, tool_name_prefix="task_")
+        names = [t["name"] for t in result]
+
+        assert "task_create-task" in names
+
+    def test_export_input_schema(self, sample_schema: InterfaceSchema):
+        """Test that input schema includes parameters."""
+        result = export_to_mcp_tools(sample_schema)
+        create_task = next(t for t in result if t["name"] == "create-task")
+
+        assert create_task["inputSchema"]["type"] == "object"
+        assert "task_title" in create_task["inputSchema"]["properties"]
+        assert "task_title" in create_task["inputSchema"]["required"]
+
+    def test_export_annotations(self, sample_schema: InterfaceSchema):
+        """Test that annotations are included."""
+        result = export_to_mcp_tools(sample_schema, include_annotations=True)
+        create_task = next(t for t in result if t["name"] == "create-task")
+
+        assert "annotations" in create_task
+        assert create_task["annotations"]["component_type"] == "ACTION"
+
+    def test_export_without_annotations(self, sample_schema: InterfaceSchema):
+        """Test that annotations can be excluded."""
+        result = export_to_mcp_tools(sample_schema, include_annotations=False)
+        create_task = next(t for t in result if t["name"] == "create-task")
+
+        assert "annotations" not in create_task
+
+    def test_exporter_server_capabilities(self, sample_schema: InterfaceSchema):
+        """Test server capabilities export."""
+        exporter = MCPToolsExporter()
+        result = exporter.export_as_server_capabilities(sample_schema)
+
+        assert "protocolVersion" in result
+        assert "capabilities" in result
+        assert "serverInfo" in result
+        assert "tools" in result
+        assert result["serverInfo"]["name"] == "Test Task Manager"
+
+
+# ============================================
+# Test Markdown Exporter
+# ============================================
+
+class TestMarkdownExporter:
+    """Test Markdown export functionality."""
+
+    def test_export_returns_string(self, sample_schema: InterfaceSchema):
+        """Test that export returns a string."""
+        result = export_to_markdown(sample_schema)
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_export_includes_title(self, sample_schema: InterfaceSchema):
+        """Test that title is included."""
+        result = export_to_markdown(sample_schema)
+
+        assert "# Test Task Manager" in result
+
+    def test_export_includes_description(self, sample_schema: InterfaceSchema):
+        """Test that description is included."""
+        result = export_to_markdown(sample_schema)
+
+        assert "A test task management schema" in result
+
+    def test_export_includes_version(self, sample_schema: InterfaceSchema):
+        """Test that version is included."""
+        result = export_to_markdown(sample_schema)
+
+        assert "1.0.0" in result
+
+    def test_export_includes_domain_info(self, sample_schema: InterfaceSchema):
+        """Test that domain info is included."""
+        result = export_to_markdown(sample_schema)
+
+        assert "task-management" in result
+
+    def test_export_includes_toc(self, sample_schema: InterfaceSchema):
+        """Test that table of contents is included."""
+        result = export_to_markdown(sample_schema, include_toc=True)
+
+        assert "Table of Contents" in result
+
+    def test_export_without_toc(self, sample_schema: InterfaceSchema):
+        """Test that TOC can be excluded."""
+        result = export_to_markdown(sample_schema, include_toc=False)
+
+        assert "Table of Contents" not in result
+
+    def test_export_includes_commands(self, sample_schema: InterfaceSchema):
+        """Test that commands are included."""
+        result = export_to_markdown(sample_schema)
+
+        assert "Create a new task" in result
+        assert "create task" in result
+
+    def test_export_includes_examples(self, sample_schema: InterfaceSchema):
+        """Test that examples are included."""
+        result = export_to_markdown(sample_schema, include_examples=True)
+
+        assert "Create a task to review code" in result
+
+    def test_export_includes_parameters(self, sample_schema: InterfaceSchema):
+        """Test that parameters are included."""
+        result = export_to_markdown(sample_schema)
+
+        assert "task_title" in result
+
+    def test_export_includes_feedback(self, sample_schema: InterfaceSchema):
+        """Test that feedback templates are included."""
+        result = export_to_markdown(sample_schema)
+
+        assert "Task '{title}' created successfully" in result
+
+    def test_export_quick_reference(self, sample_schema: InterfaceSchema):
+        """Test quick reference export."""
+        exporter = MarkdownExporter()
+        result = exporter.export_quick_reference(sample_schema)
+
+        assert "Quick Reference" in result
+        assert "| Command |" in result
+
+
+# ============================================
+# Test TypeScript Exporter
+# ============================================
+
+class TestTypeScriptExporter:
+    """Test TypeScript export functionality."""
+
+    def test_to_pascal_case(self):
+        """Test PascalCase conversion."""
+        assert to_pascal_case("create-task") == "CreateTask"
+        assert to_pascal_case("list_tasks") == "ListTasks"
+        assert to_pascal_case("hello-world-test") == "HelloWorldTest"
+
+    def test_to_camel_case(self):
+        """Test camelCase conversion."""
+        assert to_camel_case("create-task") == "createTask"
+        assert to_camel_case("list_tasks") == "listTasks"
+
+    def test_export_returns_string(self, sample_schema: InterfaceSchema):
+        """Test that export returns a string."""
+        result = export_to_typescript(sample_schema)
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_export_includes_header(self, sample_schema: InterfaceSchema):
+        """Test that header comment is included."""
+        result = export_to_typescript(sample_schema)
+
+        assert "Test Task Manager" in result
+        assert "Auto-generated" in result
+
+    def test_export_includes_enums(self, sample_schema: InterfaceSchema):
+        """Test that enums are included."""
+        exporter = TypeScriptExporter(include_enums=True)
+        result = exporter.export(sample_schema)
+
+        assert "export enum LUIComponentType" in result
+        assert "export enum ParameterType" in result
+
+    def test_export_includes_params_interface(self, sample_schema: InterfaceSchema):
+        """Test that parameter interfaces are generated."""
+        result = export_to_typescript(sample_schema)
+
+        assert "CreateTaskParams" in result
+        assert "taskTitle" in result
+
+    def test_export_includes_result_interface(self, sample_schema: InterfaceSchema):
+        """Test that result interfaces are generated."""
+        result = export_to_typescript(sample_schema)
+
+        assert "CreateTaskResult" in result
+        assert "success: boolean" in result
+
+    def test_export_includes_schema_interface(self, sample_schema: InterfaceSchema):
+        """Test that schema interface is generated."""
+        result = export_to_typescript(sample_schema)
+
+        assert "TestSchemaV1Schema" in result
+        assert "schemaId:" in result
+
+    def test_export_includes_action_types(self, sample_schema: InterfaceSchema):
+        """Test that action types are generated."""
+        result = export_to_typescript(sample_schema)
+
+        assert "ActionName" in result
+        assert "ActionHandlers" in result
+
+    def test_export_with_namespace(self, sample_schema: InterfaceSchema):
+        """Test namespace wrapping."""
+        result = export_to_typescript(sample_schema, namespace="TaskManager")
+
+        assert "export namespace TaskManager" in result
+
+    def test_export_jsdoc_comments(self, sample_schema: InterfaceSchema):
+        """Test JSDoc comments."""
+        result = export_to_typescript(sample_schema, include_jsdoc=True)
+
+        assert "/**" in result
+        assert "Create a new task" in result
+
+    def test_exporter_declaration_file(self, sample_schema: InterfaceSchema):
+        """Test declaration file export."""
+        exporter = TypeScriptExporter()
+        result = exporter.export_declaration_file(sample_schema)
+
+        assert "// Type definitions for" in result
+
+
+# ============================================
+# Test Integration
+# ============================================
+
+class TestExportIntegration:
+    """Test export integration with example schema."""
+
+    def test_load_and_export_example_schema(self):
+        """Test loading and exporting the example schema file."""
+        schema_path = Path(__file__).parent.parent / "examples" / "task_manager_schema.json"
+
+        if not schema_path.exists():
+            pytest.skip("Example schema file not found")
+
+        with open(schema_path) as f:
+            schema_data = json.load(f)
+
+        # Import here to avoid circular imports
+        from lui_simulator.simulator import load_schema_from_dict
+
+        schema = load_schema_from_dict(schema_data)
+
+        # Test all exporters
+        openapi = export_to_openapi(schema)
+        assert openapi["info"]["title"] == "Task Manager LUI"
+        assert len(openapi["paths"]) == 7
+
+        mcp_tools = export_to_mcp_tools(schema)
+        assert len(mcp_tools) == 7
+
+        markdown = export_to_markdown(schema)
+        assert "Task Manager LUI" in markdown
+
+        typescript = export_to_typescript(schema)
+        assert "TaskManagerV1Schema" in typescript
+
+    def test_openapi_is_valid_json(self, sample_schema: InterfaceSchema):
+        """Test that OpenAPI export produces valid JSON."""
+        result = export_to_openapi(sample_schema)
+        json_str = json.dumps(result)
+
+        # Should not raise
+        parsed = json.loads(json_str)
+        assert parsed == result
+
+    def test_mcp_is_valid_json(self, sample_schema: InterfaceSchema):
+        """Test that MCP export produces valid JSON."""
+        result = export_to_mcp_tools(sample_schema)
+        json_str = json.dumps(result)
+
+        # Should not raise
+        parsed = json.loads(json_str)
+        assert parsed == result


### PR DESCRIPTION
## Summary

- Implements exporters to integrate LUI schemas with external systems
- Creates OpenAPI, MCP tools, Markdown, and TypeScript export formats
- Provides integration examples for common use cases

### New Module: `lui_schema_export`

| Exporter | Purpose | Output |
|----------|---------|--------|
| `openapi.py` | OpenAPI 3.0 specification | JSON dict |
| `mcp_tools.py` | Model Context Protocol tools | JSON list |
| `markdown.py` | Human-readable documentation | Markdown string |
| `typescript.py` | TypeScript type definitions | `.ts` code |

### Usage Examples

```python
from lui_schema_export import (
    export_to_openapi,
    export_to_mcp_tools,
    export_to_markdown,
    export_to_typescript,
)

# Export to OpenAPI
openapi_spec = export_to_openapi(schema, server_url="https://api.example.com")

# Export to MCP tools
mcp_tools = export_to_mcp_tools(schema, tool_name_prefix="task_")

# Export to Markdown documentation
docs = export_to_markdown(schema, include_toc=True)

# Export to TypeScript types
types = export_to_typescript(schema, namespace="TaskManager")
```

### Integration Examples (`examples/integration/`)

- `export_demo.py`: Export schema to all formats
- `mcp_server_example.py`: Generate MCP server configuration and handler stubs
- `openapi_client_example.py`: Generate Python API client from OpenAPI export

## Test plan

- [x] Run all 189 tests (50 new export tests + existing tests)
- [x] Verify pyright passes with 0 errors
- [ ] Run integration examples to verify output
- [ ] Verify generated OpenAPI is valid per spec

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)