### PR TITLE
feat(multimodal): implement multi-modal response generation function (Issue #40)

### DIFF
--- a/baml_src/multimodal_generation.baml
+++ b/baml_src/multimodal_generation.baml
@@ -1,0 +1,885 @@
+// Multi-Modal Response Generation
+// Main BAML function for generating multi-modal responses
+// Issue #40 - Phase 1: Multi-Modal LUI Support
+
+// Note: Uses existing types from response_generation.baml:
+// - ResponseTone (PROFESSIONAL, FRIENDLY, EMPATHETIC, ENTHUSIASTIC, CALM, DIRECT, PLAYFUL)
+// - FormalityLevel (VERY_FORMAL, FORMAL, NEUTRAL, CASUAL, VERY_CASUAL)
+
+// ============================================
+// Response Persona Types
+// ============================================
+
+/// Response persona configuration for multi-modal generation
+class ResponsePersona {
+  name string @description("Persona name for identification")
+  description string? @description("Description of this persona")
+  tone ResponseTone @description("Communication tone")
+  formality FormalityLevel @description("Level of formality")
+  personality PersonalityConfig? @description("Personality traits")
+  brand_guidelines BrandGuidelines? @description("Brand-specific guidelines")
+  language_preferences LanguagePreferences? @description("Language and localization preferences")
+}
+
+/// Personality configuration for response generation
+class PersonalityConfig {
+  is_humorous bool @description("Include appropriate humor")
+  is_encouraging bool @description("Add encouraging remarks")
+  is_concise bool @description("Prefer brevity")
+  uses_analogies bool @description("Use analogies for explanation")
+  is_proactive bool @description("Anticipate user needs")
+  empathy_level EmpathyLevel? @description("Level of emotional responsiveness")
+}
+
+/// Empathy levels for response generation
+enum EmpathyLevel {
+  LOW @description("Minimal emotional acknowledgment")
+  MODERATE @description("Balanced emotional response")
+  HIGH @description("Strong emotional attunement")
+}
+
+/// Brand-specific guidelines for response generation
+class BrandGuidelines {
+  brand_name string @description("Brand name")
+  voice_description string @description("Description of brand voice")
+  key_phrases string[]? @description("Signature phrases to use")
+  avoided_phrases string[]? @description("Phrases to avoid")
+  emoji_usage EmojiUsage @description("How to use emojis")
+  signature_elements string[]? @description("Unique brand elements")
+}
+
+/// Emoji usage preferences
+enum EmojiUsage {
+  NONE @description("Never use emojis")
+  MINIMAL @description("Occasional, subtle use")
+  MODERATE @description("Regular, balanced use")
+  EXPRESSIVE @description("Frequent, expressive use")
+}
+
+/// Language and localization preferences
+class LanguagePreferences {
+  primary_language string @description("Primary language code (e.g., 'en-US')")
+  reading_level ReadingLevel? @description("Target reading level")
+  use_contractions bool? @description("Use contractions in text")
+  date_format string? @description("Preferred date format")
+  number_format string? @description("Preferred number format")
+  currency_symbol string? @description("Preferred currency symbol")
+}
+
+// ============================================
+// Generation Context Types
+// ============================================
+
+/// Context for multi-modal response generation
+class GenerationContext {
+  session_id string? @description("Session identifier for continuity")
+  turn_count int? @description("Number of turns in conversation")
+  last_response_modality Modality? @description("Modality of last response")
+  user_feedback_history UserFeedbackSummary? @description("Summary of user feedback")
+  performance_hints PerformanceHints? @description("Performance optimization hints")
+}
+
+/// Summary of user feedback for adaptation
+class UserFeedbackSummary {
+  preferred_length ResponseLength? @description("Preferred response length")
+  preferred_detail DetailLevel? @description("Preferred level of detail")
+  positive_reactions string[]? @description("Types of responses user liked")
+  negative_reactions string[]? @description("Types of responses user disliked")
+}
+
+/// Preferred response length
+enum ResponseLength {
+  VERY_SHORT @description("Minimal, essential information only")
+  SHORT @description("Brief, concise responses")
+  MEDIUM @description("Balanced detail")
+  LONG @description("Comprehensive responses")
+  DETAILED @description("Full explanations with examples")
+}
+
+/// Level of detail in responses
+enum DetailLevel {
+  OVERVIEW @description("High-level summary only")
+  STANDARD @description("Normal level of detail")
+  COMPREHENSIVE @description("Thorough coverage")
+  EXHAUSTIVE @description("Complete detail with edge cases")
+}
+
+/// Performance optimization hints
+class PerformanceHints {
+  max_response_time_ms int? @description("Target max response time")
+  bandwidth_constraint BandwidthConstraint? @description("Network bandwidth limitations")
+  prefer_cached bool? @description("Prefer cached responses")
+}
+
+/// Bandwidth constraints for response optimization
+enum BandwidthConstraint {
+  NONE @description("No bandwidth constraints")
+  LOW @description("Limited bandwidth, minimize data")
+  VERY_LOW @description("Very limited, essential only")
+}
+
+// ============================================
+// Generation Result Types
+// ============================================
+
+/// Result of multi-modal response generation
+class GenerationResult {
+  response MultiModalResponse @description("The generated multi-modal response")
+  generation_metadata GenerationMetadata @description("Metadata about generation")
+  quality_metrics QualityMetrics? @description("Quality assessment metrics")
+  alternatives AlternativeResponse[]? @description("Alternative response options")
+}
+
+/// Metadata about the generation process
+class GenerationMetadata {
+  generation_time_ms int @description("Time taken to generate response")
+  modality_selection_rationale string @description("Why this modality was chosen")
+  persona_applied string @description("Persona name that was applied")
+  accessibility_adaptations string[]? @description("Accessibility adaptations made")
+  content_warnings string[]? @description("Any content warnings")
+}
+
+/// Quality metrics for generated response
+class QualityMetrics {
+  clarity_score float @description("Clarity of the response (0-1)")
+  relevance_score float @description("Relevance to the intent (0-1)")
+  completeness_score float @description("Completeness of information (0-1)")
+  accessibility_score float @description("Accessibility compliance (0-1)")
+  brand_alignment_score float? @description("Alignment with brand guidelines (0-1)")
+}
+
+/// Alternative response option
+class AlternativeResponse {
+  response MultiModalResponse @description("Alternative response")
+  rationale string @description("Why this is a good alternative")
+  use_case string @description("When to prefer this alternative")
+}
+
+// ============================================
+// Quick Reply Types
+// ============================================
+
+/// Quick reply suggestion for user
+class QuickReply {
+  id string @description("Unique identifier")
+  label string @description("Display text")
+  value string @description("Value sent when selected")
+  icon string? @description("Optional icon identifier")
+  is_primary bool @description("Whether this is the primary suggestion")
+}
+
+/// Collection of quick replies with metadata
+class QuickReplySet {
+  replies QuickReply[] @description("List of quick replies")
+  max_visible int? @description("Maximum to show initially")
+  layout QuickReplyLayout @description("How to display replies")
+}
+
+/// Layout for quick replies
+enum QuickReplyLayout {
+  HORIZONTAL @description("Horizontal row of buttons")
+  VERTICAL @description("Vertical list")
+  GRID @description("Grid layout")
+  CHIPS @description("Chip/pill style")
+}
+
+// ============================================
+// Main Generation Functions
+// ============================================
+
+/// Generate a complete multi-modal response
+function GenerateMultiModalResponse(
+  intent: IntentExtraction,
+  action_result: ActionResult?,
+  conversation_context: ConversationContext,
+  modality_context: ModalityContext,
+  persona: ResponsePersona?,
+  generation_context: GenerationContext?,
+  user_accessibility_needs: AccessibilityNeed[]?
+) -> MultiModalResponse {
+  client "anthropic/claude-sonnet-4-20250514"
+  prompt #"
+    Generate a multi-modal response for this interaction.
+
+    ## Intent
+    - Detected Intent: {{ intent.detected_intent }}
+    - Confidence: {{ intent.confidence }}
+    {% if intent.extracted_parameters %}
+    - Parameters: {{ intent.extracted_parameters }}
+    {% endif %}
+    {% if intent.suggested_clarification %}
+    - Needs Clarification: {{ intent.suggested_clarification }}
+    {% endif %}
+
+    {% if action_result %}
+    ## Action Result
+    - Status: {{ action_result.status }}
+    {% if action_result.data %}
+    - Data: {{ action_result.data }}
+    {% endif %}
+    {% if action_result.error_message %}
+    - Error: {{ action_result.error_message }}
+    {% endif %}
+    {% if action_result.affected_entities %}
+    - Affected: {{ action_result.affected_entities }}
+    {% endif %}
+    {% endif %}
+
+    ## Conversation Context
+    {% if conversation_context.recent_messages %}
+    - Recent Messages: {{ conversation_context.recent_messages }}
+    {% endif %}
+    {% if conversation_context.current_state %}
+    - Current State: {{ conversation_context.current_state }}
+    {% endif %}
+    {% if conversation_context.active_entity %}
+    - Active Entity: {{ conversation_context.active_entity }}
+    {% endif %}
+
+    ## Modality Context
+    - Available Modalities: {{ modality_context.available_modalities }}
+    - Device:
+      - Screen: {{ modality_context.device_capabilities.has_screen }} (Size: {{ modality_context.device_capabilities.screen_size }})
+      - Speaker: {{ modality_context.device_capabilities.has_speaker }}
+      - Microphone: {{ modality_context.device_capabilities.has_microphone }}
+      - Keyboard: {{ modality_context.device_capabilities.has_keyboard }}
+    - Content Type: {{ modality_context.content_type }}
+    - Message Length: {{ modality_context.message_length }}
+    - Priority: {{ modality_context.priority }}
+    {% if modality_context.environment_context %}
+    - Environment:
+      - Noise: {{ modality_context.environment_context.noise_level }}
+      - Privacy: {{ modality_context.environment_context.privacy_level }}
+      - Mobile: {{ modality_context.environment_context.mobility }}
+      - Hands-Free: {{ modality_context.environment_context.hands_free_required }}
+      - Eyes-Free: {{ modality_context.environment_context.eyes_free_required }}
+    {% endif %}
+    {% if modality_context.user_preference %}
+    - User Preference: {{ modality_context.user_preference }}
+    {% endif %}
+
+    {% if persona %}
+    ## Response Persona
+    - Name: {{ persona.name }}
+    - Tone: {{ persona.tone }}
+    - Formality: {{ persona.formality }}
+    {% if persona.personality %}
+    - Personality:
+      - Humorous: {{ persona.personality.is_humorous }}
+      - Encouraging: {{ persona.personality.is_encouraging }}
+      - Concise: {{ persona.personality.is_concise }}
+      - Uses Analogies: {{ persona.personality.uses_analogies }}
+      - Proactive: {{ persona.personality.is_proactive }}
+    {% endif %}
+    {% if persona.brand_guidelines %}
+    - Brand: {{ persona.brand_guidelines.brand_name }}
+    - Voice: {{ persona.brand_guidelines.voice_description }}
+    {% if persona.brand_guidelines.key_phrases %}
+    - Use phrases: {{ persona.brand_guidelines.key_phrases }}
+    {% endif %}
+    {% if persona.brand_guidelines.avoided_phrases %}
+    - Avoid phrases: {{ persona.brand_guidelines.avoided_phrases }}
+    {% endif %}
+    - Emoji usage: {{ persona.brand_guidelines.emoji_usage }}
+    {% endif %}
+    {% if persona.language_preferences %}
+    - Language: {{ persona.language_preferences.primary_language }}
+    {% if persona.language_preferences.reading_level %}
+    - Reading Level: {{ persona.language_preferences.reading_level }}
+    {% endif %}
+    {% endif %}
+    {% endif %}
+
+    {% if generation_context %}
+    ## Generation Context
+    {% if generation_context.turn_count %}
+    - Turn Count: {{ generation_context.turn_count }}
+    {% endif %}
+    {% if generation_context.last_response_modality %}
+    - Last Modality: {{ generation_context.last_response_modality }}
+    {% endif %}
+    {% if generation_context.user_feedback_history %}
+    - Preferred Length: {{ generation_context.user_feedback_history.preferred_length }}
+    - Preferred Detail: {{ generation_context.user_feedback_history.preferred_detail }}
+    {% endif %}
+    {% endif %}
+
+    {% if user_accessibility_needs %}
+    ## Accessibility Needs
+    {{ user_accessibility_needs }}
+    {% endif %}
+
+    ## Generation Guidelines
+
+    ### Primary Modality Selection
+    Choose primary modality based on:
+    1. **Accessibility needs OVERRIDE all other factors**
+       - VISUAL impairment: Use VOICE, avoid visual-only
+       - AUDITORY impairment: Use TEXT/VISUAL, avoid audio-only
+       - MOTOR impairment: Prefer VOICE input
+       - COGNITIVE: Simpler, shorter responses
+
+    2. **Content-Modality Match**
+       | Content Type    | Best Modality | Rationale |
+       |-----------------|---------------|-----------|
+       | CONFIRMATION    | VOICE         | Quick, non-intrusive |
+       | ERROR           | TEXT + VISUAL | Persistent, actionable |
+       | DATA_TABLE      | VISUAL        | Spatial comparison |
+       | LONG_TEXT       | TEXT          | Skimmable, searchable |
+       | SHORT_RESPONSE  | VOICE or TEXT | User preference |
+       | LIST            | VISUAL        | Easy scanning |
+
+    3. **Environmental factors**
+       - Loud → Avoid VOICE
+       - Public → Avoid audio output
+       - Mobile → Prefer VOICE
+       - Eyes-free → Must use VOICE
+       - Hands-free → Must use VOICE
+
+    ### Text Response Guidelines
+    - Clear, concise language
+    - Match reading level to user (if specified)
+    - Include 2-4 quick reply suggestions when appropriate
+    - Use markdown formatting for structured content
+    - Keep paragraphs short for mobile readability
+
+    ### Voice Response Guidelines
+    - Conversational, natural tone
+    - Use SSML for emphasis, pauses, pronunciation
+    - Keep under 30 seconds of speech (~75 words)
+    - Always provide plain_text fallback
+    - Use appropriate prosody for emotion/emphasis
+    - Structure: greeting → main content → call to action
+
+    ### Visual Element Guidelines
+    - Use when comparing data or showing structure
+    - Always include alt_text for accessibility
+    - Provide fallback_text for screen readers
+    - Limit interactive elements to 3-4 maximum
+    - Use appropriate visual types:
+      - CARD for structured info
+      - TABLE for comparisons
+      - LIST for sequences
+      - BUTTON_GROUP for actions
+
+    ### Accessibility Requirements
+    - Set aria_live appropriately (POLITE for updates, ASSERTIVE for errors)
+    - Include role attributes for screen readers
+    - Match cognitive_load to user needs
+    - Ensure high contrast support
+    - Support keyboard navigation
+    - Provide text alternatives for all visuals
+
+    ### Action Limits
+    - Maximum 4 primary actions
+    - Always have one clear primary action
+    - Mark destructive actions appropriately
+    - Include keyboard shortcuts where applicable
+
+    ## Response Structure
+    Generate a response with:
+    1. Unique response_id (format: "resp_" + context)
+    2. Appropriate primary_modality
+    3. Text response (always include for fallback)
+    4. Voice response (if voice is available)
+    5. Visual elements (if visual is available and appropriate)
+    6. Actions (limited to 3-4 max)
+    7. Complete accessibility metadata
+
+    {{ ctx.output_format }}
+  "#
+}
+
+/// Generate a multi-modal response with full generation metadata
+function GenerateMultiModalResponseWithMetadata(
+  intent: IntentExtraction,
+  action_result: ActionResult?,
+  conversation_context: ConversationContext,
+  modality_context: ModalityContext,
+  persona: ResponsePersona?,
+  generation_context: GenerationContext?,
+  user_accessibility_needs: AccessibilityNeed[]?
+) -> GenerationResult {
+  client "anthropic/claude-sonnet-4-20250514"
+  prompt #"
+    Generate a complete multi-modal response with quality metrics.
+
+    ## Input Context
+    - Intent: {{ intent.detected_intent }} (confidence: {{ intent.confidence }})
+    {% if action_result %}
+    - Action Result: {{ action_result.status }}
+    {% endif %}
+    - Available Modalities: {{ modality_context.available_modalities }}
+    - Content Type: {{ modality_context.content_type }}
+    {% if persona %}
+    - Persona: {{ persona.name }} ({{ persona.tone }}, {{ persona.formality }})
+    {% endif %}
+    {% if user_accessibility_needs %}
+    - Accessibility Needs: {{ user_accessibility_needs }}
+    {% endif %}
+
+    ## Task
+    1. Generate an appropriate multi-modal response
+    2. Provide metadata about the generation
+    3. Calculate quality metrics
+    4. Optionally provide alternatives
+
+    ## Guidelines
+    - Follow the same guidelines as GenerateMultiModalResponse
+    - Assess quality across clarity, relevance, completeness, accessibility
+    - Explain modality selection rationale
+    - Note any accessibility adaptations made
+    - Provide alternatives if the primary response has limitations
+
+    {{ ctx.output_format }}
+  "#
+}
+
+/// Generate quick reply suggestions for a response
+function GenerateQuickReplies(
+  response_context: string,
+  intent: IntentExtraction,
+  max_replies: int?,
+  include_navigation: bool?
+) -> QuickReplySet {
+  client "anthropic/claude-sonnet-4-20250514"
+  prompt #"
+    Generate quick reply suggestions for a multi-modal response.
+
+    ## Context
+    {{ response_context }}
+
+    ## Intent
+    - Detected: {{ intent.detected_intent }}
+    - Confidence: {{ intent.confidence }}
+    {% if intent.extracted_parameters %}
+    - Parameters: {{ intent.extracted_parameters }}
+    {% endif %}
+
+    ## Requirements
+    - Maximum replies: {{ max_replies | default(4) }}
+    - Include navigation: {{ include_navigation | default(false) }}
+
+    ## Guidelines
+    - Suggestions should be logical next steps
+    - Keep labels short (2-4 words)
+    - Make one suggestion primary
+    - Include undo/cancel if action was taken
+    - Match user's apparent expertise level
+    {% if include_navigation %}
+    - Include navigation options (back, home, help)
+    {% endif %}
+
+    {{ ctx.output_format }}
+  "#
+}
+
+/// Adapt a response to a different modality
+function AdaptResponseToModality(
+  original_response: MultiModalResponse,
+  target_modality: Modality,
+  preserve_priority: PreservePriority?
+) -> MultiModalResponse {
+  client "anthropic/claude-sonnet-4-20250514"
+  prompt #"
+    Adapt this multi-modal response to a different target modality.
+
+    ## Original Response
+    - ID: {{ original_response.response_id }}
+    - Primary Modality: {{ original_response.primary_modality }}
+    {% if original_response.text %}
+    - Text: {{ original_response.text.content }}
+    {% endif %}
+    {% if original_response.voice %}
+    - Voice: {{ original_response.voice.text }}
+    {% endif %}
+    {% if original_response.visuals %}
+    - Visuals: {{ original_response.visuals | length }} elements
+    {% endif %}
+
+    ## Target Modality
+    {{ target_modality }}
+
+    {% if preserve_priority %}
+    ## Preservation Priority
+    - Critical: {{ preserve_priority.critical_elements }}
+    - Important: {{ preserve_priority.important_elements }}
+    - Optional: {{ preserve_priority.optional_elements }}
+    - Acceptable Loss: {{ preserve_priority.acceptable_loss }}
+    {% endif %}
+
+    ## Guidelines
+    1. Preserve all critical information
+    2. Adapt format to target modality strengths
+    3. Maintain accessibility
+    4. Update response_id with suffix "_adapted"
+
+    ### Modality-Specific Adaptations
+    - To TEXT: Convert voice to readable text, describe visuals
+    - To VOICE: Make text conversational, describe visuals verbally
+    - To VISUAL: Structure text as cards/lists, add visual hierarchy
+    - To HYBRID: Combine complementary modalities
+
+    {{ ctx.output_format }}
+  "#
+}
+
+/// Validate a generated multi-modal response
+function ValidateMultiModalResponse(
+  response: MultiModalResponse,
+  modality_context: ModalityContext,
+  user_accessibility_needs: AccessibilityNeed[]?
+) -> ResponseValidation {
+  client "anthropic/claude-sonnet-4-20250514"
+  prompt #"
+    Validate this multi-modal response for quality and compliance.
+
+    ## Response
+    - ID: {{ response.response_id }}
+    - Primary Modality: {{ response.primary_modality }}
+    {% if response.text %}
+    - Has Text: Yes ({{ response.text.content | length }} chars)
+    {% endif %}
+    {% if response.voice %}
+    - Has Voice: Yes
+    {% endif %}
+    {% if response.visuals %}
+    - Has Visuals: Yes ({{ response.visuals | length }} elements)
+    {% endif %}
+    {% if response.actions %}
+    - Has Actions: Yes ({{ response.actions | length }} actions)
+    {% endif %}
+    - Accessibility: aria_live={{ response.accessibility.aria_live }}, cognitive_load={{ response.accessibility.cognitive_load }}
+
+    ## Context
+    - Available: {{ modality_context.available_modalities }}
+    - Device: Screen={{ modality_context.device_capabilities.has_screen }}, Speaker={{ modality_context.device_capabilities.has_speaker }}
+
+    {% if user_accessibility_needs %}
+    ## Accessibility Needs
+    {{ user_accessibility_needs }}
+    {% endif %}
+
+    ## Validation Checks
+    1. Is primary modality available on device?
+    2. Does response have required components for primary modality?
+    3. Are accessibility requirements met?
+    4. Is action count within limits (≤4)?
+    5. Is voice response under 30 seconds (~75 words)?
+    6. Do all visuals have alt_text?
+    7. Is SSML valid (if present)?
+    8. Is cognitive load appropriate for user?
+
+    {{ ctx.output_format }}
+  "#
+}
+
+/// Response validation result
+class ResponseValidation {
+  is_valid bool @description("Whether response passes all checks")
+  is_optimal bool @description("Whether response is optimal for context")
+  issues ValidationIssue[] @description("List of validation issues")
+  suggestions string[]? @description("Improvement suggestions")
+  accessibility_compliant bool @description("Meets accessibility requirements")
+  estimated_voice_duration_seconds float? @description("Estimated voice duration")
+}
+
+/// A validation issue found in the response
+class ValidationIssue {
+  severity ValidationSeverity @description("Severity of the issue")
+  category string @description("Category of the issue")
+  message string @description("Description of the issue")
+  field string? @description("Field with the issue")
+  recommendation string? @description("How to fix")
+}
+
+// Note: ValidationSeverity is defined in entity_definitions.baml (ERROR, WARNING, INFO)
+
+// ============================================
+// Test Cases
+// ============================================
+
+test generate_confirmation_response {
+  functions [GenerateMultiModalResponse]
+  args {
+    intent {
+      detected_intent CREATE
+      confidence 0.95
+      extracted_parameters [
+        {
+          name "task_name"
+          value "Review PR #123"
+          confidence 0.98
+          source EXPLICIT
+        }
+      ]
+      ambiguity null
+      suggested_clarification null
+      raw_input "Create a task to review PR 123"
+      entities_referenced []
+      is_compound false
+    }
+    action_result {
+      status SUCCESS
+      data "task_id: 456"
+      error_message null
+      metadata null
+      affected_entities ["task_456"]
+    }
+    conversation_context {
+      recent_messages []
+      current_state "task_list"
+      active_entity null
+      user_preferences null
+    }
+    modality_context {
+      available_modalities [TEXT, VOICE, VISUAL]
+      user_preference null
+      device_capabilities {
+        has_screen true
+        has_speaker true
+        has_microphone true
+        has_keyboard true
+        screen_size MEDIUM
+        supports_touch true
+        supports_voice_commands true
+        bandwidth_quality "high"
+      }
+      environment_context {
+        noise_level QUIET
+        privacy_level PRIVATE
+        mobility false
+        hands_free_required false
+        eyes_free_required false
+        time_of_day "morning"
+      }
+      content_type CONFIRMATION
+      message_length SHORT
+      priority NORMAL
+      previous_modality null
+      interaction_count 1
+      error_occurred false
+    }
+    persona {
+      name "Helpful Assistant"
+      description "A friendly and efficient assistant"
+      tone FRIENDLY
+      formality CASUAL
+      personality {
+        is_humorous false
+        is_encouraging true
+        is_concise true
+        uses_analogies false
+        is_proactive false
+        empathy_level MODERATE
+      }
+      brand_guidelines null
+      language_preferences {
+        primary_language "en-US"
+        reading_level null
+        use_contractions true
+        date_format null
+        number_format null
+        currency_symbol null
+      }
+    }
+    generation_context null
+    user_accessibility_needs null
+  }
+}
+
+test generate_error_response {
+  functions [GenerateMultiModalResponse]
+  args {
+    intent {
+      detected_intent READ
+      confidence 0.75
+      extracted_parameters [
+        {
+          name "task_name"
+          value "meeting notes"
+          confidence 0.6
+          source INFERRED
+        }
+      ]
+      ambiguity {
+        type ENTITY_AMBIGUITY
+        options ["Meeting notes - weekly", "Meeting notes - daily", "Meeting notes - project"]
+        needs_clarification true
+      }
+      suggested_clarification "Did you mean one of these tasks?"
+      raw_input "Show me the meeting notes task"
+      entities_referenced []
+      is_compound false
+    }
+    action_result {
+      status NOT_FOUND
+      data null
+      error_message "No task found with exact name 'meeting notes'"
+      metadata null
+      affected_entities []
+    }
+    conversation_context {
+      recent_messages []
+      current_state "search"
+      active_entity null
+      user_preferences null
+    }
+    modality_context {
+      available_modalities [TEXT, VISUAL]
+      user_preference TEXT
+      device_capabilities {
+        has_screen true
+        has_speaker false
+        has_microphone false
+        has_keyboard true
+        screen_size LARGE
+        supports_touch false
+        supports_voice_commands false
+        bandwidth_quality "high"
+      }
+      environment_context null
+      content_type ERROR
+      message_length MEDIUM
+      priority HIGH
+      previous_modality TEXT
+      interaction_count 3
+      error_occurred true
+    }
+    persona null
+    generation_context null
+    user_accessibility_needs null
+  }
+}
+
+test generate_data_display_response {
+  functions [GenerateMultiModalResponse]
+  args {
+    intent {
+      detected_intent LIST
+      confidence 0.92
+      extracted_parameters [
+        {
+          name "filter"
+          value "high priority"
+          confidence 0.88
+          source EXPLICIT
+        }
+      ]
+      ambiguity null
+      suggested_clarification null
+      raw_input "Show me my high priority tasks"
+      entities_referenced []
+      is_compound false
+    }
+    action_result {
+      status SUCCESS
+      data "[{\"id\":\"1\",\"title\":\"Review PR\",\"priority\":\"high\",\"due\":\"tomorrow\"},{\"id\":\"2\",\"title\":\"Update docs\",\"priority\":\"high\",\"due\":\"next week\"},{\"id\":\"3\",\"title\":\"Fix bug\",\"priority\":\"high\",\"due\":\"today\"}]"
+      error_message null
+      metadata {
+        affected_count 3
+        execution_time_ms 150
+        warnings null
+        additional_info null
+      }
+      affected_entities ["task_1", "task_2", "task_3"]
+    }
+    conversation_context {
+      recent_messages []
+      current_state "task_list"
+      active_entity null
+      user_preferences null
+    }
+    modality_context {
+      available_modalities [TEXT, VOICE, VISUAL, HYBRID]
+      user_preference null
+      device_capabilities {
+        has_screen true
+        has_speaker true
+        has_microphone true
+        has_keyboard true
+        screen_size LARGE
+        supports_touch false
+        supports_voice_commands true
+        bandwidth_quality "high"
+      }
+      environment_context {
+        noise_level MODERATE
+        privacy_level SEMI_PRIVATE
+        mobility false
+        hands_free_required false
+        eyes_free_required false
+        time_of_day "afternoon"
+      }
+      content_type DATA_TABLE
+      message_length MEDIUM
+      priority NORMAL
+      previous_modality null
+      interaction_count 1
+      error_occurred false
+    }
+    persona null
+    generation_context null
+    user_accessibility_needs null
+  }
+}
+
+test generate_accessibility_focused_response {
+  functions [GenerateMultiModalResponse]
+  args {
+    intent {
+      detected_intent READ
+      confidence 0.9
+      extracted_parameters []
+      ambiguity null
+      suggested_clarification null
+      raw_input "What's on my calendar today?"
+      entities_referenced []
+      is_compound false
+    }
+    action_result {
+      status SUCCESS
+      data "2 meetings: Team standup at 10am, Project review at 2pm"
+      error_message null
+      metadata null
+      affected_entities []
+    }
+    conversation_context {
+      recent_messages []
+      current_state "calendar"
+      active_entity null
+      user_preferences null
+    }
+    modality_context {
+      available_modalities [TEXT, VOICE]
+      user_preference VOICE
+      device_capabilities {
+        has_screen true
+        has_speaker true
+        has_microphone true
+        has_keyboard false
+        screen_size SMALL
+        supports_touch true
+        supports_voice_commands true
+        bandwidth_quality "medium"
+      }
+      environment_context {
+        noise_level QUIET
+        privacy_level PRIVATE
+        mobility true
+        hands_free_required true
+        eyes_free_required false
+        time_of_day "morning"
+      }
+      content_type SHORT_RESPONSE
+      message_length SHORT
+      priority NORMAL
+      previous_modality VOICE
+      interaction_count 5
+      error_occurred false
+    }
+    persona null
+    generation_context null
+    user_accessibility_needs [VISUAL]
+  }
+}

--- a/tests/test_multimodal_generation.py
+++ b/tests/test_multimodal_generation.py
@@ -1,0 +1,943 @@
+"""Tests for multi-modal response generation types."""
+
+from __future__ import annotations
+
+from baml_client.types import (
+    # Enums - existing
+    ResponseTone,
+    FormalityLevel,
+    ValidationSeverity,
+    Modality,
+    ReadingLevel,
+    # Enums - new
+    EmpathyLevel,
+    EmojiUsage,
+    ResponseLength,
+    DetailLevel,
+    BandwidthConstraint,
+    QuickReplyLayout,
+    # Classes - new
+    ResponsePersona,
+    PersonalityConfig,
+    BrandGuidelines,
+    LanguagePreferences,
+    GenerationContext,
+    UserFeedbackSummary,
+    PerformanceHints,
+    GenerationResult,
+    GenerationMetadata,
+    QualityMetrics,
+    AlternativeResponse,
+    QuickReply,
+    QuickReplySet,
+    ResponseValidation,
+    ValidationIssue,
+    # Classes - existing (for integration)
+    MultiModalResponse,
+    TextResponse,
+    AccessibilityMeta,
+    AriaLiveType,
+    CognitiveLoad,
+    TextFormat,
+)
+
+
+# ============================================
+# Enum Tests
+# ============================================
+
+
+class TestEmpathyLevelEnum:
+    """Tests for EmpathyLevel enum."""
+
+    def test_all_values_exist(self) -> None:
+        """Test all empathy level values are defined."""
+        assert EmpathyLevel.LOW.value == "LOW"
+        assert EmpathyLevel.MODERATE.value == "MODERATE"
+        assert EmpathyLevel.HIGH.value == "HIGH"
+
+    def test_enum_count(self) -> None:
+        """Test correct number of values."""
+        assert len(EmpathyLevel) == 3
+
+
+class TestEmojiUsageEnum:
+    """Tests for EmojiUsage enum."""
+
+    def test_all_values_exist(self) -> None:
+        """Test all emoji usage values are defined."""
+        assert EmojiUsage.NONE.value == "NONE"
+        assert EmojiUsage.MINIMAL.value == "MINIMAL"
+        assert EmojiUsage.MODERATE.value == "MODERATE"
+        assert EmojiUsage.EXPRESSIVE.value == "EXPRESSIVE"
+
+    def test_enum_count(self) -> None:
+        """Test correct number of values."""
+        assert len(EmojiUsage) == 4
+
+
+class TestResponseLengthEnum:
+    """Tests for ResponseLength enum."""
+
+    def test_all_values_exist(self) -> None:
+        """Test all response length values are defined."""
+        assert ResponseLength.VERY_SHORT.value == "VERY_SHORT"
+        assert ResponseLength.SHORT.value == "SHORT"
+        assert ResponseLength.MEDIUM.value == "MEDIUM"
+        assert ResponseLength.LONG.value == "LONG"
+        assert ResponseLength.DETAILED.value == "DETAILED"
+
+    def test_enum_count(self) -> None:
+        """Test correct number of values."""
+        assert len(ResponseLength) == 5
+
+
+class TestDetailLevelEnum:
+    """Tests for DetailLevel enum."""
+
+    def test_all_values_exist(self) -> None:
+        """Test all detail level values are defined."""
+        assert DetailLevel.OVERVIEW.value == "OVERVIEW"
+        assert DetailLevel.STANDARD.value == "STANDARD"
+        assert DetailLevel.COMPREHENSIVE.value == "COMPREHENSIVE"
+        assert DetailLevel.EXHAUSTIVE.value == "EXHAUSTIVE"
+
+    def test_enum_count(self) -> None:
+        """Test correct number of values."""
+        assert len(DetailLevel) == 4
+
+
+class TestBandwidthConstraintEnum:
+    """Tests for BandwidthConstraint enum."""
+
+    def test_all_values_exist(self) -> None:
+        """Test all bandwidth constraint values are defined."""
+        assert BandwidthConstraint.NONE.value == "NONE"
+        assert BandwidthConstraint.LOW.value == "LOW"
+        assert BandwidthConstraint.VERY_LOW.value == "VERY_LOW"
+
+    def test_enum_count(self) -> None:
+        """Test correct number of values."""
+        assert len(BandwidthConstraint) == 3
+
+
+class TestQuickReplyLayoutEnum:
+    """Tests for QuickReplyLayout enum."""
+
+    def test_all_values_exist(self) -> None:
+        """Test all quick reply layout values are defined."""
+        assert QuickReplyLayout.HORIZONTAL.value == "HORIZONTAL"
+        assert QuickReplyLayout.VERTICAL.value == "VERTICAL"
+        assert QuickReplyLayout.GRID.value == "GRID"
+        assert QuickReplyLayout.CHIPS.value == "CHIPS"
+
+    def test_enum_count(self) -> None:
+        """Test correct number of values."""
+        assert len(QuickReplyLayout) == 4
+
+
+# ============================================
+# PersonalityConfig Tests
+# ============================================
+
+
+class TestPersonalityConfig:
+    """Tests for PersonalityConfig class."""
+
+    def test_create_basic_personality(self) -> None:
+        """Test creating a basic personality config."""
+        config = PersonalityConfig(
+            is_humorous=False,
+            is_encouraging=True,
+            is_concise=True,
+            uses_analogies=False,
+            is_proactive=True,
+        )
+
+        assert config.is_humorous is False
+        assert config.is_encouraging is True
+        assert config.is_concise is True
+        assert config.uses_analogies is False
+        assert config.is_proactive is True
+        assert config.empathy_level is None
+
+    def test_create_with_empathy(self) -> None:
+        """Test creating personality config with empathy level."""
+        config = PersonalityConfig(
+            is_humorous=True,
+            is_encouraging=True,
+            is_concise=False,
+            uses_analogies=True,
+            is_proactive=False,
+            empathy_level=EmpathyLevel.HIGH,
+        )
+
+        assert config.is_humorous is True
+        assert config.empathy_level == EmpathyLevel.HIGH
+
+
+# ============================================
+# BrandGuidelines Tests
+# ============================================
+
+
+class TestBrandGuidelines:
+    """Tests for BrandGuidelines class."""
+
+    def test_create_basic_guidelines(self) -> None:
+        """Test creating basic brand guidelines."""
+        guidelines = BrandGuidelines(
+            brand_name="Acme Corp",
+            voice_description="Professional yet approachable",
+            emoji_usage=EmojiUsage.MINIMAL,
+        )
+
+        assert guidelines.brand_name == "Acme Corp"
+        assert guidelines.voice_description == "Professional yet approachable"
+        assert guidelines.emoji_usage == EmojiUsage.MINIMAL
+        assert guidelines.key_phrases is None
+
+    def test_create_full_guidelines(self) -> None:
+        """Test creating complete brand guidelines."""
+        guidelines = BrandGuidelines(
+            brand_name="FunCorp",
+            voice_description="Playful and energetic",
+            key_phrases=["Let's go!", "You got this!"],
+            avoided_phrases=["Unfortunately", "We regret"],
+            emoji_usage=EmojiUsage.EXPRESSIVE,
+            signature_elements=["sparkle effect", "celebration animation"],
+        )
+
+        assert guidelines.key_phrases is not None
+        assert guidelines.avoided_phrases is not None
+        assert len(guidelines.key_phrases) == 2
+        assert len(guidelines.avoided_phrases) == 2
+        assert guidelines.emoji_usage == EmojiUsage.EXPRESSIVE
+
+
+# ============================================
+# LanguagePreferences Tests
+# ============================================
+
+
+class TestLanguagePreferences:
+    """Tests for LanguagePreferences class."""
+
+    def test_create_basic_preferences(self) -> None:
+        """Test creating basic language preferences."""
+        prefs = LanguagePreferences(
+            primary_language="en-US",
+        )
+
+        assert prefs.primary_language == "en-US"
+        assert prefs.reading_level is None
+        assert prefs.use_contractions is None
+
+    def test_create_full_preferences(self) -> None:
+        """Test creating complete language preferences."""
+        prefs = LanguagePreferences(
+            primary_language="en-GB",
+            reading_level=ReadingLevel.HIGH_SCHOOL,
+            use_contractions=True,
+            date_format="DD/MM/YYYY",
+            number_format="1.000,00",
+            currency_symbol="£",
+        )
+
+        assert prefs.primary_language == "en-GB"
+        assert prefs.reading_level == ReadingLevel.HIGH_SCHOOL
+        assert prefs.use_contractions is True
+        assert prefs.currency_symbol == "£"
+
+
+# ============================================
+# ResponsePersona Tests
+# ============================================
+
+
+class TestResponsePersona:
+    """Tests for ResponsePersona class."""
+
+    def test_create_basic_persona(self) -> None:
+        """Test creating a basic response persona."""
+        persona = ResponsePersona(
+            name="Helpful Assistant",
+            tone=ResponseTone.FRIENDLY,
+            formality=FormalityLevel.CASUAL,
+        )
+
+        assert persona.name == "Helpful Assistant"
+        assert persona.tone == ResponseTone.FRIENDLY
+        assert persona.formality == FormalityLevel.CASUAL
+        assert persona.description is None
+        assert persona.personality is None
+
+    def test_create_full_persona(self) -> None:
+        """Test creating a complete response persona."""
+        personality = PersonalityConfig(
+            is_humorous=False,
+            is_encouraging=True,
+            is_concise=True,
+            uses_analogies=False,
+            is_proactive=True,
+            empathy_level=EmpathyLevel.MODERATE,
+        )
+
+        brand = BrandGuidelines(
+            brand_name="TechCorp",
+            voice_description="Modern and efficient",
+            emoji_usage=EmojiUsage.MINIMAL,
+        )
+
+        lang = LanguagePreferences(
+            primary_language="en-US",
+            use_contractions=True,
+        )
+
+        persona = ResponsePersona(
+            name="Corporate Assistant",
+            description="Professional assistant for enterprise users",
+            tone=ResponseTone.PROFESSIONAL,
+            formality=FormalityLevel.FORMAL,
+            personality=personality,
+            brand_guidelines=brand,
+            language_preferences=lang,
+        )
+
+        assert persona.name == "Corporate Assistant"
+        assert persona.description is not None
+        assert persona.personality is not None
+        assert persona.brand_guidelines is not None
+        assert persona.language_preferences is not None
+
+
+# ============================================
+# UserFeedbackSummary Tests
+# ============================================
+
+
+class TestUserFeedbackSummary:
+    """Tests for UserFeedbackSummary class."""
+
+    def test_create_empty_summary(self) -> None:
+        """Test creating an empty feedback summary."""
+        summary = UserFeedbackSummary()
+
+        assert summary.preferred_length is None
+        assert summary.preferred_detail is None
+
+    def test_create_full_summary(self) -> None:
+        """Test creating a complete feedback summary."""
+        summary = UserFeedbackSummary(
+            preferred_length=ResponseLength.SHORT,
+            preferred_detail=DetailLevel.STANDARD,
+            positive_reactions=["concise answers", "helpful examples"],
+            negative_reactions=["too verbose", "technical jargon"],
+        )
+
+        assert summary.preferred_length == ResponseLength.SHORT
+        assert summary.preferred_detail == DetailLevel.STANDARD
+        assert summary.positive_reactions is not None
+        assert summary.negative_reactions is not None
+        assert len(summary.positive_reactions) == 2
+        assert len(summary.negative_reactions) == 2
+
+
+# ============================================
+# PerformanceHints Tests
+# ============================================
+
+
+class TestPerformanceHints:
+    """Tests for PerformanceHints class."""
+
+    def test_create_basic_hints(self) -> None:
+        """Test creating basic performance hints."""
+        hints = PerformanceHints()
+
+        assert hints.max_response_time_ms is None
+        assert hints.bandwidth_constraint is None
+
+    def test_create_constrained_hints(self) -> None:
+        """Test creating constrained performance hints."""
+        hints = PerformanceHints(
+            max_response_time_ms=500,
+            bandwidth_constraint=BandwidthConstraint.LOW,
+            prefer_cached=True,
+        )
+
+        assert hints.max_response_time_ms == 500
+        assert hints.bandwidth_constraint == BandwidthConstraint.LOW
+        assert hints.prefer_cached is True
+
+
+# ============================================
+# GenerationContext Tests
+# ============================================
+
+
+class TestGenerationContext:
+    """Tests for GenerationContext class."""
+
+    def test_create_empty_context(self) -> None:
+        """Test creating an empty generation context."""
+        context = GenerationContext()
+
+        assert context.session_id is None
+        assert context.turn_count is None
+
+    def test_create_full_context(self) -> None:
+        """Test creating a complete generation context."""
+        feedback = UserFeedbackSummary(
+            preferred_length=ResponseLength.MEDIUM,
+        )
+
+        hints = PerformanceHints(
+            max_response_time_ms=1000,
+        )
+
+        context = GenerationContext(
+            session_id="session_123",
+            turn_count=5,
+            last_response_modality=Modality.TEXT,
+            user_feedback_history=feedback,
+            performance_hints=hints,
+        )
+
+        assert context.session_id == "session_123"
+        assert context.turn_count == 5
+        assert context.last_response_modality == Modality.TEXT
+        assert context.user_feedback_history is not None
+        assert context.performance_hints is not None
+
+
+# ============================================
+# QualityMetrics Tests
+# ============================================
+
+
+class TestQualityMetrics:
+    """Tests for QualityMetrics class."""
+
+    def test_create_basic_metrics(self) -> None:
+        """Test creating basic quality metrics."""
+        metrics = QualityMetrics(
+            clarity_score=0.9,
+            relevance_score=0.85,
+            completeness_score=0.8,
+            accessibility_score=0.95,
+        )
+
+        assert metrics.clarity_score == 0.9
+        assert metrics.relevance_score == 0.85
+        assert metrics.completeness_score == 0.8
+        assert metrics.accessibility_score == 0.95
+        assert metrics.brand_alignment_score is None
+
+    def test_create_full_metrics(self) -> None:
+        """Test creating complete quality metrics."""
+        metrics = QualityMetrics(
+            clarity_score=0.92,
+            relevance_score=0.88,
+            completeness_score=0.85,
+            accessibility_score=0.97,
+            brand_alignment_score=0.9,
+        )
+
+        assert metrics.brand_alignment_score == 0.9
+
+
+# ============================================
+# GenerationMetadata Tests
+# ============================================
+
+
+class TestGenerationMetadata:
+    """Tests for GenerationMetadata class."""
+
+    def test_create_basic_metadata(self) -> None:
+        """Test creating basic generation metadata."""
+        metadata = GenerationMetadata(
+            generation_time_ms=150,
+            modality_selection_rationale="Voice selected for confirmation message",
+            persona_applied="Helpful Assistant",
+        )
+
+        assert metadata.generation_time_ms == 150
+        assert "Voice" in metadata.modality_selection_rationale
+        assert metadata.persona_applied == "Helpful Assistant"
+        assert metadata.accessibility_adaptations is None
+
+    def test_create_full_metadata(self) -> None:
+        """Test creating complete generation metadata."""
+        metadata = GenerationMetadata(
+            generation_time_ms=250,
+            modality_selection_rationale="Text selected due to loud environment",
+            persona_applied="Corporate Assistant",
+            accessibility_adaptations=["High contrast mode", "Screen reader optimized"],
+            content_warnings=["Contains technical terms"],
+        )
+
+        assert metadata.accessibility_adaptations is not None
+        assert metadata.content_warnings is not None
+        assert len(metadata.accessibility_adaptations) == 2
+        assert len(metadata.content_warnings) == 1
+
+
+# ============================================
+# QuickReply Tests
+# ============================================
+
+
+class TestQuickReply:
+    """Tests for QuickReply class."""
+
+    def test_create_basic_reply(self) -> None:
+        """Test creating a basic quick reply."""
+        reply = QuickReply(
+            id="reply_1",
+            label="Show details",
+            value="show_details",
+            is_primary=True,
+        )
+
+        assert reply.id == "reply_1"
+        assert reply.label == "Show details"
+        assert reply.value == "show_details"
+        assert reply.is_primary is True
+        assert reply.icon is None
+
+    def test_create_with_icon(self) -> None:
+        """Test creating quick reply with icon."""
+        reply = QuickReply(
+            id="reply_2",
+            label="Cancel",
+            value="cancel_action",
+            icon="close",
+            is_primary=False,
+        )
+
+        assert reply.icon == "close"
+        assert reply.is_primary is False
+
+
+# ============================================
+# QuickReplySet Tests
+# ============================================
+
+
+class TestQuickReplySet:
+    """Tests for QuickReplySet class."""
+
+    def test_create_reply_set(self) -> None:
+        """Test creating a quick reply set."""
+        replies = [
+            QuickReply(id="1", label="Yes", value="yes", is_primary=True),
+            QuickReply(id="2", label="No", value="no", is_primary=False),
+            QuickReply(id="3", label="Cancel", value="cancel", is_primary=False),
+        ]
+
+        reply_set = QuickReplySet(
+            replies=replies,
+            layout=QuickReplyLayout.HORIZONTAL,
+        )
+
+        assert len(reply_set.replies) == 3
+        assert reply_set.layout == QuickReplyLayout.HORIZONTAL
+        assert reply_set.max_visible is None
+
+    def test_create_with_max_visible(self) -> None:
+        """Test creating reply set with max visible limit."""
+        replies = [
+            QuickReply(id=str(i), label=f"Option {i}", value=f"opt_{i}", is_primary=i == 1)
+            for i in range(1, 6)
+        ]
+
+        reply_set = QuickReplySet(
+            replies=replies,
+            max_visible=3,
+            layout=QuickReplyLayout.CHIPS,
+        )
+
+        assert len(reply_set.replies) == 5
+        assert reply_set.max_visible == 3
+
+
+# ============================================
+# ValidationIssue Tests
+# ============================================
+
+
+class TestValidationIssue:
+    """Tests for ValidationIssue class."""
+
+    def test_create_error_issue(self) -> None:
+        """Test creating an error validation issue."""
+        issue = ValidationIssue(
+            severity=ValidationSeverity.ERROR,
+            category="modality",
+            message="Primary modality not available on device",
+        )
+
+        assert issue.severity == ValidationSeverity.ERROR
+        assert issue.category == "modality"
+        assert issue.field is None
+
+    def test_create_warning_with_recommendation(self) -> None:
+        """Test creating a warning with recommendation."""
+        issue = ValidationIssue(
+            severity=ValidationSeverity.WARNING,
+            category="accessibility",
+            message="Voice response exceeds 30 seconds",
+            field="voice.text",
+            recommendation="Shorten the response or split into parts",
+        )
+
+        assert issue.severity == ValidationSeverity.WARNING
+        assert issue.field == "voice.text"
+        assert issue.recommendation is not None
+
+
+# ============================================
+# ResponseValidation Tests
+# ============================================
+
+
+class TestResponseValidation:
+    """Tests for ResponseValidation class."""
+
+    def test_create_valid_response(self) -> None:
+        """Test creating a validation result for valid response."""
+        validation = ResponseValidation(
+            is_valid=True,
+            is_optimal=True,
+            issues=[],
+            accessibility_compliant=True,
+        )
+
+        assert validation.is_valid is True
+        assert validation.is_optimal is True
+        assert len(validation.issues) == 0
+        assert validation.accessibility_compliant is True
+
+    def test_create_with_issues(self) -> None:
+        """Test creating a validation with issues."""
+        issues = [
+            ValidationIssue(
+                severity=ValidationSeverity.WARNING,
+                category="voice",
+                message="Voice duration may exceed recommendation",
+            ),
+            ValidationIssue(
+                severity=ValidationSeverity.INFO,
+                category="actions",
+                message="Consider adding undo action",
+            ),
+        ]
+
+        validation = ResponseValidation(
+            is_valid=True,
+            is_optimal=False,
+            issues=issues,
+            suggestions=["Shorten voice content", "Add undo button"],
+            accessibility_compliant=True,
+            estimated_voice_duration_seconds=35.5,
+        )
+
+        assert validation.is_valid is True
+        assert validation.is_optimal is False
+        assert len(validation.issues) == 2
+        assert validation.suggestions is not None
+        assert len(validation.suggestions) == 2
+        assert validation.estimated_voice_duration_seconds == 35.5
+
+
+# ============================================
+# GenerationResult Tests
+# ============================================
+
+
+class TestGenerationResult:
+    """Tests for GenerationResult class."""
+
+    def test_create_basic_result(self) -> None:
+        """Test creating a basic generation result."""
+        response = MultiModalResponse(
+            response_id="resp_001",
+            primary_modality=Modality.TEXT,
+            accessibility=AccessibilityMeta(
+                aria_live=AriaLiveType.POLITE,
+                cognitive_load=CognitiveLoad.LOW,
+                supports_screen_reader=True,
+                supports_keyboard_nav=True,
+                high_contrast_available=True,
+                reduced_motion_safe=True,
+            ),
+        )
+
+        metadata = GenerationMetadata(
+            generation_time_ms=120,
+            modality_selection_rationale="Text for error message",
+            persona_applied="Default",
+        )
+
+        result = GenerationResult(
+            response=response,
+            generation_metadata=metadata,
+        )
+
+        assert result.response.response_id == "resp_001"
+        assert result.generation_metadata.generation_time_ms == 120
+        assert result.quality_metrics is None
+        assert result.alternatives is None
+
+    def test_create_full_result(self) -> None:
+        """Test creating a complete generation result with alternatives."""
+        response = MultiModalResponse(
+            response_id="resp_002",
+            primary_modality=Modality.VOICE,
+            text=TextResponse(
+                content="Task created: Review PR #123",
+                format=TextFormat.PLAIN,
+            ),
+            accessibility=AccessibilityMeta(
+                aria_live=AriaLiveType.POLITE,
+                cognitive_load=CognitiveLoad.MINIMAL,
+                supports_screen_reader=True,
+                supports_keyboard_nav=True,
+                high_contrast_available=True,
+                reduced_motion_safe=True,
+            ),
+        )
+
+        metadata = GenerationMetadata(
+            generation_time_ms=180,
+            modality_selection_rationale="Voice for confirmation",
+            persona_applied="Helpful Assistant",
+        )
+
+        metrics = QualityMetrics(
+            clarity_score=0.95,
+            relevance_score=0.92,
+            completeness_score=0.88,
+            accessibility_score=0.97,
+        )
+
+        # Alternative response
+        alt_response = MultiModalResponse(
+            response_id="resp_002_alt",
+            primary_modality=Modality.TEXT,
+            accessibility=AccessibilityMeta(
+                aria_live=AriaLiveType.POLITE,
+                cognitive_load=CognitiveLoad.MINIMAL,
+                supports_screen_reader=True,
+                supports_keyboard_nav=True,
+                high_contrast_available=True,
+                reduced_motion_safe=True,
+            ),
+        )
+
+        alternative = AlternativeResponse(
+            response=alt_response,
+            rationale="Text-only for noisy environments",
+            use_case="When voice output is not appropriate",
+        )
+
+        result = GenerationResult(
+            response=response,
+            generation_metadata=metadata,
+            quality_metrics=metrics,
+            alternatives=[alternative],
+        )
+
+        assert result.quality_metrics is not None
+        assert result.quality_metrics.clarity_score == 0.95
+        assert result.alternatives is not None
+        assert len(result.alternatives) == 1
+        assert result.alternatives[0].rationale == "Text-only for noisy environments"
+
+
+# ============================================
+# Integration Tests
+# ============================================
+
+
+class TestMultiModalGenerationIntegration:
+    """Integration tests for multi-modal generation types."""
+
+    def test_full_generation_workflow(self) -> None:
+        """Test complete generation workflow with all types."""
+        # 1. Create persona
+        persona = ResponsePersona(
+            name="Customer Support",
+            description="Helpful support persona",
+            tone=ResponseTone.EMPATHETIC,
+            formality=FormalityLevel.CASUAL,
+            personality=PersonalityConfig(
+                is_humorous=False,
+                is_encouraging=True,
+                is_concise=True,
+                uses_analogies=False,
+                is_proactive=True,
+                empathy_level=EmpathyLevel.HIGH,
+            ),
+        )
+
+        # 2. Create generation context
+        context = GenerationContext(
+            session_id="support_session_001",
+            turn_count=3,
+            last_response_modality=Modality.TEXT,
+            user_feedback_history=UserFeedbackSummary(
+                preferred_length=ResponseLength.SHORT,
+            ),
+        )
+
+        # 3. Create response
+        response = MultiModalResponse(
+            response_id="support_resp_001",
+            primary_modality=Modality.TEXT,
+            text=TextResponse(
+                content="I understand that's frustrating. Let me help you resolve this.",
+                format=TextFormat.PLAIN,
+            ),
+            accessibility=AccessibilityMeta(
+                aria_live=AriaLiveType.POLITE,
+                cognitive_load=CognitiveLoad.LOW,
+                supports_screen_reader=True,
+                supports_keyboard_nav=True,
+                high_contrast_available=True,
+                reduced_motion_safe=True,
+            ),
+        )
+
+        # 4. Create generation metadata
+        metadata = GenerationMetadata(
+            generation_time_ms=95,
+            modality_selection_rationale="Text for support conversation continuity",
+            persona_applied=persona.name,
+            accessibility_adaptations=["Screen reader compatible"],
+        )
+
+        # 5. Create quality metrics
+        metrics = QualityMetrics(
+            clarity_score=0.92,
+            relevance_score=0.88,
+            completeness_score=0.85,
+            accessibility_score=0.96,
+        )
+
+        # 6. Create result
+        result = GenerationResult(
+            response=response,
+            generation_metadata=metadata,
+            quality_metrics=metrics,
+        )
+
+        # Assertions
+        assert persona.personality is not None
+        assert persona.personality.empathy_level == EmpathyLevel.HIGH
+        assert context.user_feedback_history is not None
+        assert context.user_feedback_history.preferred_length == ResponseLength.SHORT
+        assert result.response.text is not None
+        assert result.response.text.content.startswith("I understand")
+        assert result.generation_metadata.persona_applied == "Customer Support"
+        assert result.quality_metrics is not None
+        assert result.quality_metrics.accessibility_score > 0.9
+
+    def test_quick_replies_for_confirmation(self) -> None:
+        """Test quick replies for confirmation response."""
+        replies = QuickReplySet(
+            replies=[
+                QuickReply(
+                    id="details",
+                    label="Show details",
+                    value="show_task_details",
+                    icon="info",
+                    is_primary=True,
+                ),
+                QuickReply(
+                    id="create",
+                    label="Create another",
+                    value="create_new_task",
+                    icon="add",
+                    is_primary=False,
+                ),
+                QuickReply(
+                    id="undo",
+                    label="Undo",
+                    value="undo_creation",
+                    icon="undo",
+                    is_primary=False,
+                ),
+            ],
+            max_visible=3,
+            layout=QuickReplyLayout.CHIPS,
+        )
+
+        assert len(replies.replies) == 3
+        assert replies.replies[0].is_primary is True
+        assert replies.layout == QuickReplyLayout.CHIPS
+
+    def test_validation_for_response(self) -> None:
+        """Test validation of a generated response."""
+        issues = [
+            ValidationIssue(
+                severity=ValidationSeverity.INFO,
+                category="optimization",
+                message="Response could be more concise",
+                recommendation="Consider shortening by 20%",
+            ),
+        ]
+
+        validation = ResponseValidation(
+            is_valid=True,
+            is_optimal=False,
+            issues=issues,
+            suggestions=["Reduce response length"],
+            accessibility_compliant=True,
+            estimated_voice_duration_seconds=22.5,
+        )
+
+        assert validation.is_valid is True
+        assert validation.is_optimal is False
+        assert len(validation.issues) == 1
+        assert validation.issues[0].severity == ValidationSeverity.INFO
+
+
+class TestTypeImports:
+    """Tests to verify all generation types are importable."""
+
+    def test_all_new_enums_importable(self) -> None:
+        """Test all new enum imports work."""
+        assert EmpathyLevel is not None
+        assert EmojiUsage is not None
+        assert ResponseLength is not None
+        assert DetailLevel is not None
+        assert BandwidthConstraint is not None
+        assert QuickReplyLayout is not None
+
+    def test_all_new_classes_importable(self) -> None:
+        """Test all new class imports work."""
+        assert ResponsePersona is not None
+        assert PersonalityConfig is not None
+        assert BrandGuidelines is not None
+        assert LanguagePreferences is not None
+        assert GenerationContext is not None
+        assert UserFeedbackSummary is not None
+        assert PerformanceHints is not None
+        assert GenerationResult is not None
+        assert GenerationMetadata is not None
+        assert QualityMetrics is not None
+        assert AlternativeResponse is not None
+        assert QuickReply is not None
+        assert QuickReplySet is not None
+        assert ResponseValidation is not None
+        assert ValidationIssue is not None
+
+    def test_existing_types_available(self) -> None:
+        """Test existing types are still available."""
+        assert ResponseTone is not None
+        assert FormalityLevel is not None
+        assert ValidationSeverity is not None
+        assert Modality is not None


### PR DESCRIPTION
## Summary

Implements Phase 1 Task 1.6: Multi-Modal Response Generation for multi-modal LUI support.

### Response Persona System
- **ResponsePersona**: Complete persona configuration for response generation
- **PersonalityConfig**: Humor, empathy, conciseness, analogies, proactivity settings
- **BrandGuidelines**: Brand voice, key phrases, emoji usage, signature elements
- **LanguagePreferences**: Primary language, reading level, contractions, localization

### Generation Context
- **GenerationContext**: Session tracking, turn count, previous modality
- **UserFeedbackSummary**: Preferred response length and detail levels
- **PerformanceHints**: Response time limits, bandwidth constraints, caching

### Generation Results
- **GenerationResult**: Response with metadata, quality metrics, alternatives
- **GenerationMetadata**: Timing, modality selection rationale, accessibility adaptations
- **QualityMetrics**: Clarity, relevance, completeness, accessibility scores
- **AlternativeResponse**: Alternative options with rationale

### Quick Replies
- **QuickReply**: Individual suggestion with label, value, icon
- **QuickReplySet**: Collection with layout options (horizontal, vertical, grid, chips)

### Validation
- **ResponseValidation**: Validity, optimality, compliance checks
- **ValidationIssue**: Severity levels, categories, recommendations

### BAML Functions
- `GenerateMultiModalResponse` - Main response generation orchestrator
- `GenerateMultiModalResponseWithMetadata` - Generation with quality metrics
- `GenerateQuickReplies` - Quick reply suggestion generation
- `AdaptResponseToModality` - Modality adaptation for degradation
- `ValidateMultiModalResponse` - Response validation

## Test Plan

- [x] 46 unit tests covering all new types
- [x] Integration tests for full generation workflow
- [x] Quick reply generation tests
- [x] Validation scenario tests
- [x] All 619 tests pass
- [x] Lint and type checks pass

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)