### PR TITLE
fix(expertise): Clean up linting issues in expertise detection (#45)

### DIFF
--- a/src/lui_simulator/expertise.py
+++ b/src/lui_simulator/expertise.py
@@ -23,7 +23,6 @@ Uses Exponential Moving Average (EMA) with alpha=0.3 for score smoothing.
 import math
 import statistics
 from dataclasses import dataclass, field
-from datetime import datetime
 from enum import Enum
 from typing import Optional
 
@@ -638,7 +637,6 @@ class ExpertiseDetector:
             return None, None
 
         current_level = self._current_estimate.estimated_level
-        current_score = self._current_estimate.expertise_score
 
         if new_level == current_level:
             return "MAINTAIN", "Score within current level range"
@@ -682,15 +680,15 @@ class ExpertiseDetector:
         """Create a default estimate for cold start scenarios."""
         config = self.config.cold_start
 
-        # Default factor breakdown
-        default_factor = lambda name, weight: ExpertiseFactor(
-            factor_name=name,
-            weight=weight,
-            raw_value=config.default_score,
-            weighted_value=config.default_score * weight,
-            confidence=config.default_confidence,
-            evidence=["Cold start - using defaults"],
-        )
+        def default_factor(name: str, weight: float) -> ExpertiseFactor:
+            return ExpertiseFactor(
+                factor_name=name,
+                weight=weight,
+                raw_value=config.default_score,
+                weighted_value=config.default_score * weight,
+                confidence=config.default_confidence,
+                evidence=["Cold start - using defaults"],
+            )
 
         factor_breakdown = ExpertiseFactorBreakdown(
             command_fluency=default_factor("command_fluency", self.config.command_fluency_weight),

--- a/tests/test_expertise_detection.py
+++ b/tests/test_expertise_detection.py
@@ -13,7 +13,7 @@ Tests cover:
 
 import math
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import pytest
 
@@ -21,11 +21,9 @@ from src.lui_simulator.expertise import (
     ColdStartConfig,
     ExpertiseDetectionConfig,
     ExpertiseDetector,
-    ExpertiseEstimate,
     ExpertiseFactor,
     ExpertiseFactorBreakdown,
     ExpertiseLevel,
-    LevelThreshold,
 )
 from src.lui_simulator.metrics import (
     InteractionOutcome,
@@ -675,7 +673,6 @@ class TestLevelTransitions:
 
         # Start at intermediate level
         estimate1 = detector.estimate_expertise(create_intermediate_interactions(20))
-        initial_level = estimate1.estimated_level
 
         # Improve to expert level over time
         for _ in range(5):


### PR DESCRIPTION
## Summary

- Remove unused variable `current_score` in `_evaluate_transition()`
- Convert lambda to def for `default_factor` in `_create_default_estimate()` (E731 compliance)
- Remove unused variable `initial_level` in test
- Remove unused imports (datetime, timedelta, ExpertiseEstimate, LevelThreshold)

## Context

The expertise detection algorithm was implemented in PR #120. This PR addresses minor linting issues identified by ruff.

## Verification

All success criteria for issue #45 are met:
- ✅ Score calculation matches research weights (30%/25%/25%/20%)
- ✅ Level mapping is smooth via EMA smoothing (α=0.3) and hysteresis buffers (±0.05)
- ✅ Confidence reflects data quality with cold start penalties
- ✅ Cold-start scenarios handled gracefully (defaults to INTERMEDIATE)
- ✅ 50 unit tests covering all scenarios

## Test plan

- [x] All 50 expertise detection tests pass
- [x] Ruff linting passes with no errors
- [x] Pyright type checking passes

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)