### PR TITLE
fix(transitions): Clean up linting and type errors in level transitions (#46)

### DIFF
--- a/src/lui_simulator/transitions.py
+++ b/src/lui_simulator/transitions.py
@@ -22,10 +22,8 @@ from .expertise import ExpertiseLevel
 from .metrics import (
     FrustrationSignals,
     InteractionOutcome,
-    InteractionRecord,
     MetricsWindow,
     SignalSeverity,
-    TrendDirection,
 )
 
 
@@ -518,20 +516,22 @@ class TransitionManager:
         Returns:
             TransitionResult with execution details.
         """
-        if not decision.should_transition or decision.to_level is None:
+        if not decision.should_transition or decision.to_level is None or decision.direction is None:
             raise ValueError("Cannot execute a decision that says not to transition")
 
         now = datetime.now()
         transition_id = str(uuid.uuid4())
+        direction = decision.direction
+        to_level = decision.to_level
 
         # Create transition record
         record = TransitionRecord(
             transition_id=transition_id,
             user_id=user_id,
             timestamp=now.isoformat() + "Z",
-            direction=decision.direction,
+            direction=direction,
             from_level=decision.from_level,
-            to_level=decision.to_level,
+            to_level=to_level,
             rationale=decision.rationale,
             was_rolled_back=False,
             triggered_by="auto" if not decision.requires_confirmation else "confirmed",
@@ -560,8 +560,8 @@ class TransitionManager:
             transition_id=transition_id,
             executed_at=now.isoformat() + "Z",
             previous_level=decision.from_level,
-            new_level=decision.to_level,
-            direction=decision.direction,
+            new_level=to_level,
+            direction=direction,
             rollback_token=rollback_token,
             rollback_expires_at=rollback_expires_at,
             notification_sent=decision.user_notification is not None,

--- a/tests/test_level_transitions.py
+++ b/tests/test_level_transitions.py
@@ -12,19 +12,16 @@ Tests cover:
 """
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import pytest
 
 from src.lui_simulator.transitions import (
     ExpertiseLevel,
-    RollbackResult,
     TransitionDecision,
     TransitionDirection,
     TransitionManager,
     TransitionPolicy,
-    TransitionRecord,
-    TransitionResult,
 )
 from src.lui_simulator.metrics import (
     FrustrationSignals,


### PR DESCRIPTION
## Summary

- Remove unused imports (InteractionRecord, TrendDirection, timedelta, RollbackResult, TransitionRecord, TransitionResult)
- Fix pyright type errors by adding direction validation in `execute_transition()`
- Use validated variables for direction and to_level to satisfy type checker

## Context

The level transition logic was implemented in PR #121. This PR addresses linting issues (unused imports) and type errors (Optional types in TransitionDecision).

## Verification

All success criteria for issue #46 are met:
- ✅ Smooth, non-jarring transitions via gradual policy and cooldowns
- ✅ Encouraging, non-condescending notification messages
- ✅ Rollback capability working with token-based expiration
- ✅ Cooldown prevents oscillation (24h default)
- ✅ User preference overrides work (bypass cooldown)
- ✅ 52 unit tests covering all transition paths

## Test plan

- [x] All 52 level transition tests pass
- [x] Ruff linting passes with no errors
- [x] Pyright type checking passes

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)