### PR TITLE
fix(templates): Clean up linting and type errors in adaptive templates

### DIFF
--- a/src/lui_simulator/templates.py
+++ b/src/lui_simulator/templates.py
@@ -11,7 +11,6 @@ Key Principles:
 - What changes: length, confirmation frequency, examples, technical language
 """
 
-import re
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
@@ -630,10 +629,10 @@ class TemplateManager:
             expertise_level=variant.expertise_level,
             rendered_content=rendered_content,
             includes_examples=variant.show_examples or (
-                customization and customization.always_show_examples
+                customization is not None and customization.always_show_examples
             ),
             includes_shortcuts=variant.show_shortcuts and not (
-                customization and customization.never_show_shortcuts
+                customization is not None and customization.never_show_shortcuts
             ),
             requires_confirmation=variant.require_confirmation,
             suggested_actions=suggested_actions,

--- a/tests/test_adaptive_templates.py
+++ b/tests/test_adaptive_templates.py
@@ -4,7 +4,6 @@ Issue #47 - Phase 2: Adaptive Interface Personalization
 """
 
 import pytest
-from datetime import datetime
 from src.lui_simulator.templates import (
     TemplateManager,
     TemplatePurpose,
@@ -494,7 +493,7 @@ class TestTemplateManagerCustomization:
     def test_override_default_template(self, manager):
         """Should allow overriding default templates."""
         original = manager.get_template("task_creation")
-        original_desc = original.description if original else ""
+        assert original is not None
 
         override = AdaptiveTemplate(
             template_id="task_creation",


### PR DESCRIPTION
## Summary

- Remove unused import `re` from templates.py
- Remove unused import `datetime` from test file
- Remove unused variable `original_desc` in test, replaced with assertion
- Fix pyright type error: use `is not None` check for customization to ensure bool type instead of potential None

## Context

Issue #47 (Adaptive Response Templates) was already closed via PR #122. This PR addresses minor linting issues (unused imports) and a type error (Optional type in boolean expression).

## Test plan

- [x] All 62 adaptive template tests pass
- [x] Ruff linting passes with no errors
- [x] Pyright type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)