### PR TITLE
fix(response): Remove unused import in adaptive response tests

### DIFF
--- a/tests/test_adaptive_response.py
+++ b/tests/test_adaptive_response.py
@@ -12,7 +12,6 @@ from src.lui_simulator.adaptive_response import (
     FrustrationResponse,
     ResponseModifier,
     DEFAULT_SETTINGS,
-    LEVEL_GUIDELINES,
 )
 from src.lui_simulator.expertise import ExpertiseLevel
 from src.lui_simulator.templates import VerbosityLevel


### PR DESCRIPTION
## Summary

- Remove unused `LEVEL_GUIDELINES` import from test file

## Context

Issue #48 (Profile-Aware Response Generation) was already closed via PR #123. This PR addresses a minor linting issue (unused import).

## Test plan

- [x] All 57 adaptive response tests pass
- [x] Ruff linting passes with no errors
- [x] Pyright type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)