### PR TITLE
feat(negotiation): Implement agent card schema for A2A compatibility (#54)

### DIFF
--- a/baml_src/agent_card.baml
+++ b/baml_src/agent_card.baml
@@ -1,0 +1,251 @@
+// Agent Card Schema (A2A-compatible)
+// Complete agent advertisement format compatible with Google A2A protocol
+// Issue #54 - Phase 3: Agent-to-Agent Interface Negotiation
+
+// Dependencies:
+// - AgentIdentity, AgentMetadata, TrustLevel, TrustRequirements from agent_identity.baml
+// - AgentCapability from agent_capability.baml
+
+// ============================================
+// Protocol Types
+// ============================================
+
+/// Supported communication protocols for agent interaction
+enum ProtocolType {
+  A2A @description("Google Agent-to-Agent protocol")
+  MCP @description("Model Context Protocol (Anthropic)")
+  OPENAPI @description("OpenAPI/REST specification")
+  JSON_RPC @description("JSON-RPC 2.0 protocol")
+  GRPC @description("gRPC protocol")
+  GRAPHQL @description("GraphQL API")
+  WEBSOCKET @description("WebSocket real-time protocol")
+  CUSTOM @description("Custom protocol implementation")
+}
+
+/// Protocol version declaration
+class SupportedProtocol {
+  protocol ProtocolType @description("Protocol type")
+  version string @description("Protocol version (semver)")
+  uri string? @description("Protocol specification URI")
+  extensions string[]? @description("Supported protocol extensions")
+  deprecated bool @description("Whether this protocol version is deprecated")
+}
+
+// ============================================
+// Endpoint Types
+// ============================================
+
+/// Types of endpoints an agent can expose
+enum EndpointType {
+  PRIMARY @description("Main service endpoint")
+  FALLBACK @description("Backup endpoint for failover")
+  HEALTH_CHECK @description("Health monitoring endpoint")
+  DISCOVERY @description("Agent discovery endpoint (.well-known)")
+  METRICS @description("Metrics and observability endpoint")
+  ADMIN @description("Administrative endpoint")
+}
+
+/// Authentication methods for endpoints
+enum AuthMethod {
+  NONE @description("No authentication required")
+  API_KEY @description("API key in header or query")
+  BEARER_TOKEN @description("OAuth2 bearer token")
+  BASIC @description("HTTP Basic authentication")
+  MTLS @description("Mutual TLS certificate authentication")
+  SPIFFE @description("SPIFFE-based authentication")
+  OAUTH2 @description("OAuth 2.0 with client credentials")
+  JWT @description("JWT token authentication")
+  CUSTOM @description("Custom authentication scheme")
+}
+
+/// Authentication configuration for an endpoint
+class AuthConfig {
+  method AuthMethod @description("Authentication method")
+  header_name string? @description("Custom header name for API key/token")
+  token_endpoint string? @description("OAuth2 token endpoint URL")
+  scopes string[]? @description("Required OAuth2 scopes")
+  audience string? @description("Expected JWT audience")
+  issuer string? @description("Trusted JWT issuer")
+}
+
+/// Complete endpoint definition for AgentCard
+class CardEndpoint {
+  endpoint_type EndpointType @description("Type of endpoint")
+  url string @description("Endpoint URL")
+  protocol ProtocolType @description("Communication protocol")
+  auth_config AuthConfig? @description("Authentication configuration")
+  timeout_ms int? @description("Request timeout in milliseconds")
+  retry_policy RetryPolicy? @description("Retry policy for this endpoint")
+}
+
+/// Retry policy for endpoint calls
+class RetryPolicy {
+  max_retries int @description("Maximum number of retry attempts")
+  initial_backoff_ms int @description("Initial backoff delay in milliseconds")
+  max_backoff_ms int @description("Maximum backoff delay in milliseconds")
+  backoff_multiplier float @description("Multiplier for exponential backoff")
+  retryable_status_codes int[]? @description("HTTP status codes that trigger retry")
+}
+
+// ============================================
+// Compliance and Certification
+// ============================================
+
+/// Standard compliance certifications
+enum ComplianceStandard {
+  GDPR @description("General Data Protection Regulation (EU)")
+  CCPA @description("California Consumer Privacy Act")
+  HIPAA @description("Health Insurance Portability and Accountability Act")
+  SOC2 @description("Service Organization Control 2")
+  SOC2_TYPE1 @description("SOC 2 Type 1 certification")
+  SOC2_TYPE2 @description("SOC 2 Type 2 certification")
+  ISO27001 @description("ISO/IEC 27001 Information Security")
+  ISO27017 @description("ISO/IEC 27017 Cloud Security")
+  ISO27018 @description("ISO/IEC 27018 Cloud Privacy")
+  PCI_DSS @description("Payment Card Industry Data Security Standard")
+  FEDRAMP @description("Federal Risk and Authorization Management Program")
+  FEDRAMP_HIGH @description("FedRAMP High Impact Level")
+  FEDRAMP_MODERATE @description("FedRAMP Moderate Impact Level")
+  NIST_800_53 @description("NIST SP 800-53 Security Controls")
+  CSA_STAR @description("Cloud Security Alliance STAR")
+}
+
+/// Compliance tag with verification details
+class ComplianceTag {
+  standard ComplianceStandard @description("Compliance standard")
+  certified bool @description("Whether certification is current")
+  certificate_url string? @description("URL to compliance certificate")
+  expiry_date string? @description("ISO 8601 expiry date of certification")
+  auditor string? @description("Name of certifying auditor")
+  scope string? @description("Scope of certification")
+}
+
+/// Data handling policies for compliance
+class DataHandlingPolicy {
+  data_residency string[]? @description("Allowed data residency regions (ISO 3166-1)")
+  data_retention_days int? @description("Maximum data retention period")
+  encryption_at_rest bool @description("Whether data is encrypted at rest")
+  encryption_in_transit bool @description("Whether data is encrypted in transit")
+  pii_handling string? @description("PII handling policy description")
+  audit_logging bool @description("Whether audit logging is enabled")
+}
+
+// ============================================
+// Agent Card
+// ============================================
+
+/// Complete agent advertisement card (A2A-compatible)
+/// This is the primary format for agent discovery and capability advertisement
+class AgentCard {
+  card_version string @description("AgentCard schema version (e.g., 1.0.0)")
+  identity AgentIdentity @description("Agent identity information")
+  capabilities AgentCapability[] @description("List of advertised capabilities")
+  supported_protocols SupportedProtocol[] @description("Supported communication protocols")
+  endpoints CardEndpoint[] @description("Available service endpoints")
+  compliance_tags ComplianceTag[]? @description("Compliance certifications")
+  data_handling DataHandlingPolicy? @description("Data handling policy")
+  trust_requirements TrustRequirements? @description("Trust requirements for invocation")
+  metadata AgentMetadata? @description("Additional metadata")
+  signature string? @description("Cryptographic signature of card contents")
+}
+
+/// Lightweight agent card for discovery responses
+class AgentCardSummary {
+  agent_id string @description("Agent ID for full card retrieval")
+  name string @description("Agent name")
+  description string @description("Brief description")
+  capability_count int @description("Number of capabilities")
+  protocols ProtocolType[] @description("Supported protocols")
+  compliance_standards ComplianceStandard[] @description("Compliance standards met")
+  discovery_url string @description("URL to retrieve full AgentCard")
+}
+
+// ============================================
+// Well-Known Discovery
+// ============================================
+
+/// Response format for .well-known/agent-descriptions endpoint
+class WellKnownAgentDescriptions {
+  schema_version string @description("Schema version for this format")
+  generated_at string @description("ISO 8601 timestamp of generation")
+  agents AgentCardSummary[] @description("List of available agent summaries")
+  total_count int @description("Total number of agents available")
+  next_cursor string? @description("Cursor for pagination")
+}
+
+/// Request to retrieve agent card
+class AgentCardRequest {
+  request_id string @description("Unique request identifier")
+  agent_id string @description("ID of agent to retrieve")
+  include_capabilities bool @description("Whether to include full capability details")
+  include_signature bool @description("Whether to include cryptographic signature")
+  requested_at string @description("ISO 8601 timestamp of request")
+}
+
+/// Response containing agent card
+class AgentCardResponse {
+  request_id string @description("ID of the original request")
+  agent_card AgentCard? @description("The agent card if found")
+  found bool @description("Whether the agent was found")
+  cached bool @description("Whether response is from cache")
+  cache_expires_at string? @description("ISO 8601 timestamp when cache expires")
+  error AgentCardError? @description("Error details if not found")
+}
+
+/// Error response for agent card retrieval
+class AgentCardError {
+  error_code string @description("Machine-readable error code")
+  error_message string @description("Human-readable error message")
+  suggested_action string? @description("Suggested action to resolve")
+}
+
+// ============================================
+// Protocol Negotiation
+// ============================================
+
+/// Request to negotiate communication protocol
+class ProtocolNegotiationRequest {
+  request_id string @description("Unique request identifier")
+  client_protocols SupportedProtocol[] @description("Protocols supported by client")
+  preferred_protocol ProtocolType? @description("Client's preferred protocol")
+  capabilities_required string[]? @description("Capability IDs that must be supported")
+}
+
+/// Result of protocol negotiation
+class ProtocolNegotiationResult {
+  request_id string @description("ID of the negotiation request")
+  success bool @description("Whether negotiation succeeded")
+  selected_protocol SupportedProtocol? @description("Agreed-upon protocol")
+  selected_endpoint CardEndpoint? @description("Endpoint to use")
+  fallback_protocols SupportedProtocol[]? @description("Alternative protocols if primary fails")
+  failure_reason string? @description("Reason for negotiation failure")
+}
+
+// ============================================
+// Card Validation
+// ============================================
+
+/// Result of validating an agent card
+class CardValidationResult {
+  valid bool @description("Whether the card is valid")
+  errors CardValidationError[] @description("List of validation errors")
+  warnings CardValidationWarning[] @description("List of validation warnings")
+  signature_verified bool? @description("Whether signature verification passed")
+  a2a_compliant bool @description("Whether card is A2A-compliant")
+  mcp_compliant bool @description("Whether card is MCP-compliant")
+}
+
+/// Validation error for agent card
+class CardValidationError {
+  field string @description("Field path with error")
+  error_code string @description("Error code")
+  message string @description("Error description")
+}
+
+/// Validation warning for agent card
+class CardValidationWarning {
+  field string @description("Field path with warning")
+  warning_code string @description("Warning code")
+  message string @description("Warning description")
+  suggestion string? @description("Suggested fix")
+}

--- a/src/agent_negotiation/__init__.py
+++ b/src/agent_negotiation/__init__.py
@@ -1,0 +1,75 @@
+"""
+Agent Negotiation Module
+
+Agent-to-Agent interface negotiation components for Phase 3.
+"""
+
+from .agent_card import (
+    # Protocol types
+    ProtocolType,
+    SupportedProtocol,
+    # Endpoint types
+    EndpointType,
+    AuthMethod,
+    AuthConfig,
+    CardEndpoint,
+    RetryPolicy,
+    # Compliance types
+    ComplianceStandard,
+    ComplianceTag,
+    DataHandlingPolicy,
+    # Agent Card
+    AgentCard,
+    AgentCardSummary,
+    # Discovery types
+    WellKnownAgentDescriptions,
+    AgentCardRequest,
+    AgentCardResponse,
+    AgentCardError,
+    # Protocol negotiation
+    ProtocolNegotiationRequest,
+    ProtocolNegotiationResult,
+    # Validation
+    CardValidationResult,
+    CardValidationError,
+    CardValidationWarning,
+    # Utilities
+    AgentCardBuilder,
+    AgentCardValidator,
+    AgentCardSerializer,
+)
+
+__all__ = [
+    # Protocol types
+    "ProtocolType",
+    "SupportedProtocol",
+    # Endpoint types
+    "EndpointType",
+    "AuthMethod",
+    "AuthConfig",
+    "CardEndpoint",
+    "RetryPolicy",
+    # Compliance types
+    "ComplianceStandard",
+    "ComplianceTag",
+    "DataHandlingPolicy",
+    # Agent Card
+    "AgentCard",
+    "AgentCardSummary",
+    # Discovery types
+    "WellKnownAgentDescriptions",
+    "AgentCardRequest",
+    "AgentCardResponse",
+    "AgentCardError",
+    # Protocol negotiation
+    "ProtocolNegotiationRequest",
+    "ProtocolNegotiationResult",
+    # Validation
+    "CardValidationResult",
+    "CardValidationError",
+    "CardValidationWarning",
+    # Utilities
+    "AgentCardBuilder",
+    "AgentCardValidator",
+    "AgentCardSerializer",
+]

--- a/src/agent_negotiation/agent_card.py
+++ b/src/agent_negotiation/agent_card.py
@@ -1,0 +1,974 @@
+"""
+Agent Card Schema (A2A-compatible)
+
+Complete agent advertisement format compatible with Google A2A protocol.
+
+Issue #54 - Phase 3: Agent-to-Agent Interface Negotiation
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+import hashlib
+import json
+import uuid
+
+from src.lui_simulator.agent_types import (
+    AgentIdentity,
+    AgentMetadata,
+    AgentCapability,
+    TrustRequirements,
+)
+
+
+# ============================================
+# Protocol Types
+# ============================================
+
+
+class ProtocolType(Enum):
+    """Supported communication protocols for agent interaction."""
+
+    A2A = "a2a"  # Google Agent-to-Agent protocol
+    MCP = "mcp"  # Model Context Protocol (Anthropic)
+    OPENAPI = "openapi"  # OpenAPI/REST specification
+    JSON_RPC = "json_rpc"  # JSON-RPC 2.0 protocol
+    GRPC = "grpc"  # gRPC protocol
+    GRAPHQL = "graphql"  # GraphQL API
+    WEBSOCKET = "websocket"  # WebSocket real-time protocol
+    CUSTOM = "custom"  # Custom protocol implementation
+
+
+@dataclass
+class SupportedProtocol:
+    """Protocol version declaration."""
+
+    protocol: ProtocolType
+    version: str
+    uri: str | None = None
+    extensions: list[str] = field(default_factory=list)
+    deprecated: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "protocol": self.protocol.value,
+            "version": self.version,
+            "deprecated": self.deprecated,
+        }
+        if self.uri:
+            result["uri"] = self.uri
+        if self.extensions:
+            result["extensions"] = self.extensions
+        return result
+
+
+# ============================================
+# Endpoint Types
+# ============================================
+
+
+class EndpointType(Enum):
+    """Types of endpoints an agent can expose."""
+
+    PRIMARY = "primary"
+    FALLBACK = "fallback"
+    HEALTH_CHECK = "health_check"
+    DISCOVERY = "discovery"
+    METRICS = "metrics"
+    ADMIN = "admin"
+
+
+class AuthMethod(Enum):
+    """Authentication methods for endpoints."""
+
+    NONE = "none"
+    API_KEY = "api_key"
+    BEARER_TOKEN = "bearer_token"
+    BASIC = "basic"
+    MTLS = "mtls"
+    SPIFFE = "spiffe"
+    OAUTH2 = "oauth2"
+    JWT = "jwt"
+    CUSTOM = "custom"
+
+
+@dataclass
+class AuthConfig:
+    """Authentication configuration for an endpoint."""
+
+    method: AuthMethod
+    header_name: str | None = None
+    token_endpoint: str | None = None
+    scopes: list[str] = field(default_factory=list)
+    audience: str | None = None
+    issuer: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {"method": self.method.value}
+        if self.header_name:
+            result["header_name"] = self.header_name
+        if self.token_endpoint:
+            result["token_endpoint"] = self.token_endpoint
+        if self.scopes:
+            result["scopes"] = self.scopes
+        if self.audience:
+            result["audience"] = self.audience
+        if self.issuer:
+            result["issuer"] = self.issuer
+        return result
+
+
+@dataclass
+class RetryPolicy:
+    """Retry policy for endpoint calls."""
+
+    max_retries: int = 3
+    initial_backoff_ms: int = 100
+    max_backoff_ms: int = 10000
+    backoff_multiplier: float = 2.0
+    retryable_status_codes: list[int] = field(
+        default_factory=lambda: [429, 500, 502, 503, 504]
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "max_retries": self.max_retries,
+            "initial_backoff_ms": self.initial_backoff_ms,
+            "max_backoff_ms": self.max_backoff_ms,
+            "backoff_multiplier": self.backoff_multiplier,
+            "retryable_status_codes": self.retryable_status_codes,
+        }
+
+
+@dataclass
+class CardEndpoint:
+    """Complete endpoint definition for AgentCard."""
+
+    endpoint_type: EndpointType
+    url: str
+    protocol: ProtocolType
+    auth_config: AuthConfig | None = None
+    timeout_ms: int | None = None
+    retry_policy: RetryPolicy | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "endpoint_type": self.endpoint_type.value,
+            "url": self.url,
+            "protocol": self.protocol.value,
+        }
+        if self.auth_config:
+            result["auth_config"] = self.auth_config.to_dict()
+        if self.timeout_ms:
+            result["timeout_ms"] = self.timeout_ms
+        if self.retry_policy:
+            result["retry_policy"] = self.retry_policy.to_dict()
+        return result
+
+
+# ============================================
+# Compliance Types
+# ============================================
+
+
+class ComplianceStandard(Enum):
+    """Standard compliance certifications."""
+
+    GDPR = "gdpr"
+    CCPA = "ccpa"
+    HIPAA = "hipaa"
+    SOC2 = "soc2"
+    SOC2_TYPE1 = "soc2_type1"
+    SOC2_TYPE2 = "soc2_type2"
+    ISO27001 = "iso27001"
+    ISO27017 = "iso27017"
+    ISO27018 = "iso27018"
+    PCI_DSS = "pci_dss"
+    FEDRAMP = "fedramp"
+    FEDRAMP_HIGH = "fedramp_high"
+    FEDRAMP_MODERATE = "fedramp_moderate"
+    NIST_800_53 = "nist_800_53"
+    CSA_STAR = "csa_star"
+
+
+@dataclass
+class ComplianceTag:
+    """Compliance tag with verification details."""
+
+    standard: ComplianceStandard
+    certified: bool = True
+    certificate_url: str | None = None
+    expiry_date: str | None = None
+    auditor: str | None = None
+    scope: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "standard": self.standard.value,
+            "certified": self.certified,
+        }
+        if self.certificate_url:
+            result["certificate_url"] = self.certificate_url
+        if self.expiry_date:
+            result["expiry_date"] = self.expiry_date
+        if self.auditor:
+            result["auditor"] = self.auditor
+        if self.scope:
+            result["scope"] = self.scope
+        return result
+
+    def is_expired(self) -> bool:
+        """Check if the certification has expired."""
+        if not self.expiry_date:
+            return False
+        try:
+            expiry = datetime.fromisoformat(self.expiry_date.replace("Z", "+00:00"))
+            return expiry < datetime.now(timezone.utc)
+        except ValueError:
+            return False
+
+
+@dataclass
+class DataHandlingPolicy:
+    """Data handling policies for compliance."""
+
+    encryption_at_rest: bool = True
+    encryption_in_transit: bool = True
+    audit_logging: bool = True
+    data_residency: list[str] = field(default_factory=list)
+    data_retention_days: int | None = None
+    pii_handling: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "encryption_at_rest": self.encryption_at_rest,
+            "encryption_in_transit": self.encryption_in_transit,
+            "audit_logging": self.audit_logging,
+        }
+        if self.data_residency:
+            result["data_residency"] = self.data_residency
+        if self.data_retention_days is not None:
+            result["data_retention_days"] = self.data_retention_days
+        if self.pii_handling:
+            result["pii_handling"] = self.pii_handling
+        return result
+
+
+# ============================================
+# Agent Card
+# ============================================
+
+
+@dataclass
+class AgentCard:
+    """
+    Complete agent advertisement card (A2A-compatible).
+
+    This is the primary format for agent discovery and capability advertisement.
+    """
+
+    identity: AgentIdentity
+    capabilities: list[AgentCapability]
+    supported_protocols: list[SupportedProtocol]
+    endpoints: list[CardEndpoint]
+    card_version: str = "1.0.0"
+    compliance_tags: list[ComplianceTag] = field(default_factory=list)
+    data_handling: DataHandlingPolicy | None = None
+    trust_requirements: TrustRequirements | None = None
+    metadata: AgentMetadata | None = None
+    signature: str | None = None
+
+    def get_primary_endpoint(self) -> CardEndpoint | None:
+        """Get the primary endpoint if available."""
+        for endpoint in self.endpoints:
+            if endpoint.endpoint_type == EndpointType.PRIMARY:
+                return endpoint
+        return self.endpoints[0] if self.endpoints else None
+
+    def get_discovery_endpoint(self) -> CardEndpoint | None:
+        """Get the discovery endpoint if available."""
+        for endpoint in self.endpoints:
+            if endpoint.endpoint_type == EndpointType.DISCOVERY:
+                return endpoint
+        return None
+
+    def get_health_check_endpoint(self) -> CardEndpoint | None:
+        """Get the health check endpoint if available."""
+        for endpoint in self.endpoints:
+            if endpoint.endpoint_type == EndpointType.HEALTH_CHECK:
+                return endpoint
+        return None
+
+    def supports_protocol(self, protocol: ProtocolType) -> bool:
+        """Check if the agent supports a specific protocol."""
+        return any(p.protocol == protocol for p in self.supported_protocols)
+
+    def get_protocol(self, protocol_type: ProtocolType) -> SupportedProtocol | None:
+        """Get protocol details for a specific protocol type."""
+        for p in self.supported_protocols:
+            if p.protocol == protocol_type:
+                return p
+        return None
+
+    def is_compliant_with(self, standard: ComplianceStandard) -> bool:
+        """Check if the agent is compliant with a specific standard."""
+        return any(
+            t.standard == standard and t.certified and not t.is_expired()
+            for t in self.compliance_tags
+        )
+
+    def get_capability(self, capability_id: str) -> AgentCapability | None:
+        """Get a specific capability by ID."""
+        for cap in self.capabilities:
+            if cap.capability_id == capability_id:
+                return cap
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to A2A-compatible JSON dictionary."""
+        result: dict[str, Any] = {
+            "card_version": self.card_version,
+            "identity": {
+                "agent_id": self.identity.agent_id,
+                "name": self.identity.name,
+                "version": self.identity.version,
+                "description": self.identity.description,
+            },
+            "capabilities": [
+                {
+                    "capability_id": cap.capability_id,
+                    "capability_type": cap.capability_type.value,
+                    "name": cap.name,
+                    "description": cap.description,
+                }
+                for cap in self.capabilities
+            ],
+            "supported_protocols": [p.to_dict() for p in self.supported_protocols],
+            "endpoints": [e.to_dict() for e in self.endpoints],
+        }
+
+        if self.identity.provider:
+            result["identity"]["provider"] = self.identity.provider
+        if self.identity.trust_domain:
+            result["identity"]["trust_domain"] = self.identity.trust_domain
+
+        if self.compliance_tags:
+            result["compliance_tags"] = [t.to_dict() for t in self.compliance_tags]
+        if self.data_handling:
+            result["data_handling"] = self.data_handling.to_dict()
+        if self.trust_requirements:
+            result["trust_requirements"] = {
+                "minimum_trust_level": self.trust_requirements.minimum_trust_level.value,
+                "require_mutual_tls": self.trust_requirements.require_mutual_tls,
+                "require_attestation": self.trust_requirements.require_attestation,
+            }
+        if self.signature:
+            result["signature"] = self.signature
+
+        return result
+
+    def to_json(self, indent: int | None = 2) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def compute_hash(self) -> str:
+        """Compute SHA-256 hash of card contents (excluding signature)."""
+        card_dict = self.to_dict()
+        card_dict.pop("signature", None)
+        content = json.dumps(card_dict, sort_keys=True)
+        return hashlib.sha256(content.encode()).hexdigest()
+
+
+@dataclass
+class AgentCardSummary:
+    """Lightweight agent card for discovery responses."""
+
+    agent_id: str
+    name: str
+    description: str
+    capability_count: int
+    protocols: list[ProtocolType]
+    compliance_standards: list[ComplianceStandard]
+    discovery_url: str
+
+    @classmethod
+    def from_card(cls, card: AgentCard, discovery_url: str) -> "AgentCardSummary":
+        """Create summary from full agent card."""
+        return cls(
+            agent_id=card.identity.agent_id,
+            name=card.identity.name,
+            description=card.identity.description,
+            capability_count=len(card.capabilities),
+            protocols=[p.protocol for p in card.supported_protocols],
+            compliance_standards=[t.standard for t in card.compliance_tags if t.certified],
+            discovery_url=discovery_url,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "agent_id": self.agent_id,
+            "name": self.name,
+            "description": self.description,
+            "capability_count": self.capability_count,
+            "protocols": [p.value for p in self.protocols],
+            "compliance_standards": [s.value for s in self.compliance_standards],
+            "discovery_url": self.discovery_url,
+        }
+
+
+# ============================================
+# Well-Known Discovery
+# ============================================
+
+
+@dataclass
+class WellKnownAgentDescriptions:
+    """Response format for .well-known/agent-descriptions endpoint."""
+
+    agents: list[AgentCardSummary]
+    total_count: int
+    schema_version: str = "1.0.0"
+    generated_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    next_cursor: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "generated_at": self.generated_at,
+            "agents": [a.to_dict() for a in self.agents],
+            "total_count": self.total_count,
+        }
+        if self.next_cursor:
+            result["next_cursor"] = self.next_cursor
+        return result
+
+    def to_json(self, indent: int | None = 2) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+
+@dataclass
+class AgentCardRequest:
+    """Request to retrieve agent card."""
+
+    agent_id: str
+    request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    include_capabilities: bool = True
+    include_signature: bool = False
+    requested_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+@dataclass
+class AgentCardError:
+    """Error response for agent card retrieval."""
+
+    error_code: str
+    error_message: str
+    suggested_action: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "error_code": self.error_code,
+            "error_message": self.error_message,
+        }
+        if self.suggested_action:
+            result["suggested_action"] = self.suggested_action
+        return result
+
+
+@dataclass
+class AgentCardResponse:
+    """Response containing agent card."""
+
+    request_id: str
+    found: bool
+    agent_card: AgentCard | None = None
+    cached: bool = False
+    cache_expires_at: str | None = None
+    error: AgentCardError | None = None
+
+    @classmethod
+    def success(
+        cls,
+        request_id: str,
+        card: AgentCard,
+        cached: bool = False,
+        cache_expires_at: str | None = None,
+    ) -> "AgentCardResponse":
+        """Create a successful response."""
+        return cls(
+            request_id=request_id,
+            found=True,
+            agent_card=card,
+            cached=cached,
+            cache_expires_at=cache_expires_at,
+        )
+
+    @classmethod
+    def not_found(cls, request_id: str, agent_id: str) -> "AgentCardResponse":
+        """Create a not-found response."""
+        return cls(
+            request_id=request_id,
+            found=False,
+            error=AgentCardError(
+                error_code="AGENT_NOT_FOUND",
+                error_message=f"Agent with ID '{agent_id}' not found",
+                suggested_action="Verify the agent ID and try again",
+            ),
+        )
+
+
+# ============================================
+# Protocol Negotiation
+# ============================================
+
+
+@dataclass
+class ProtocolNegotiationRequest:
+    """Request to negotiate communication protocol."""
+
+    client_protocols: list[SupportedProtocol]
+    request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    preferred_protocol: ProtocolType | None = None
+    capabilities_required: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ProtocolNegotiationResult:
+    """Result of protocol negotiation."""
+
+    request_id: str
+    success: bool
+    selected_protocol: SupportedProtocol | None = None
+    selected_endpoint: CardEndpoint | None = None
+    fallback_protocols: list[SupportedProtocol] = field(default_factory=list)
+    failure_reason: str | None = None
+
+    @classmethod
+    def successful(
+        cls,
+        request_id: str,
+        protocol: SupportedProtocol,
+        endpoint: CardEndpoint,
+        fallbacks: list[SupportedProtocol] | None = None,
+    ) -> "ProtocolNegotiationResult":
+        """Create a successful negotiation result."""
+        return cls(
+            request_id=request_id,
+            success=True,
+            selected_protocol=protocol,
+            selected_endpoint=endpoint,
+            fallback_protocols=fallbacks or [],
+        )
+
+    @classmethod
+    def failed(cls, request_id: str, reason: str) -> "ProtocolNegotiationResult":
+        """Create a failed negotiation result."""
+        return cls(
+            request_id=request_id,
+            success=False,
+            failure_reason=reason,
+        )
+
+
+# ============================================
+# Card Validation
+# ============================================
+
+
+@dataclass
+class CardValidationError:
+    """Validation error for agent card."""
+
+    field: str
+    error_code: str
+    message: str
+
+
+@dataclass
+class CardValidationWarning:
+    """Validation warning for agent card."""
+
+    field: str
+    warning_code: str
+    message: str
+    suggestion: str | None = None
+
+
+@dataclass
+class CardValidationResult:
+    """Result of validating an agent card."""
+
+    valid: bool
+    errors: list[CardValidationError] = field(default_factory=list)
+    warnings: list[CardValidationWarning] = field(default_factory=list)
+    signature_verified: bool | None = None
+    a2a_compliant: bool = False
+    mcp_compliant: bool = False
+
+
+# ============================================
+# Utility Classes
+# ============================================
+
+
+class AgentCardBuilder:
+    """Builder for creating AgentCard instances."""
+
+    def __init__(self, identity: AgentIdentity) -> None:
+        """Initialize builder with agent identity."""
+        self._identity = identity
+        self._capabilities: list[AgentCapability] = []
+        self._protocols: list[SupportedProtocol] = []
+        self._endpoints: list[CardEndpoint] = []
+        self._compliance_tags: list[ComplianceTag] = []
+        self._data_handling: DataHandlingPolicy | None = None
+        self._trust_requirements: TrustRequirements | None = None
+        self._metadata: AgentMetadata | None = None
+
+    def add_capability(self, capability: AgentCapability) -> "AgentCardBuilder":
+        """Add a capability to the card."""
+        self._capabilities.append(capability)
+        return self
+
+    def add_protocol(
+        self,
+        protocol: ProtocolType,
+        version: str,
+        uri: str | None = None,
+        extensions: list[str] | None = None,
+    ) -> "AgentCardBuilder":
+        """Add a supported protocol."""
+        self._protocols.append(
+            SupportedProtocol(
+                protocol=protocol,
+                version=version,
+                uri=uri,
+                extensions=extensions or [],
+            )
+        )
+        return self
+
+    def add_endpoint(
+        self,
+        endpoint_type: EndpointType,
+        url: str,
+        protocol: ProtocolType,
+        auth_config: AuthConfig | None = None,
+        timeout_ms: int | None = None,
+    ) -> "AgentCardBuilder":
+        """Add an endpoint."""
+        self._endpoints.append(
+            CardEndpoint(
+                endpoint_type=endpoint_type,
+                url=url,
+                protocol=protocol,
+                auth_config=auth_config,
+                timeout_ms=timeout_ms,
+            )
+        )
+        return self
+
+    def add_compliance(
+        self,
+        standard: ComplianceStandard,
+        certified: bool = True,
+        certificate_url: str | None = None,
+        expiry_date: str | None = None,
+    ) -> "AgentCardBuilder":
+        """Add a compliance tag."""
+        self._compliance_tags.append(
+            ComplianceTag(
+                standard=standard,
+                certified=certified,
+                certificate_url=certificate_url,
+                expiry_date=expiry_date,
+            )
+        )
+        return self
+
+    def with_data_handling(
+        self,
+        encryption_at_rest: bool = True,
+        encryption_in_transit: bool = True,
+        audit_logging: bool = True,
+        data_residency: list[str] | None = None,
+    ) -> "AgentCardBuilder":
+        """Set data handling policy."""
+        self._data_handling = DataHandlingPolicy(
+            encryption_at_rest=encryption_at_rest,
+            encryption_in_transit=encryption_in_transit,
+            audit_logging=audit_logging,
+            data_residency=data_residency or [],
+        )
+        return self
+
+    def with_trust_requirements(
+        self, requirements: TrustRequirements
+    ) -> "AgentCardBuilder":
+        """Set trust requirements."""
+        self._trust_requirements = requirements
+        return self
+
+    def with_metadata(self, metadata: AgentMetadata) -> "AgentCardBuilder":
+        """Set metadata."""
+        self._metadata = metadata
+        return self
+
+    def build(self) -> AgentCard:
+        """Build the AgentCard."""
+        if not self._protocols:
+            raise ValueError("At least one protocol must be specified")
+        if not self._endpoints:
+            raise ValueError("At least one endpoint must be specified")
+
+        return AgentCard(
+            identity=self._identity,
+            capabilities=self._capabilities,
+            supported_protocols=self._protocols,
+            endpoints=self._endpoints,
+            compliance_tags=self._compliance_tags,
+            data_handling=self._data_handling,
+            trust_requirements=self._trust_requirements,
+            metadata=self._metadata,
+        )
+
+
+class AgentCardValidator:
+    """Validator for AgentCard instances."""
+
+    def validate(self, card: AgentCard) -> CardValidationResult:
+        """Validate an agent card."""
+        errors: list[CardValidationError] = []
+        warnings: list[CardValidationWarning] = []
+
+        # Validate identity
+        if not card.identity.agent_id:
+            errors.append(
+                CardValidationError(
+                    field="identity.agent_id",
+                    error_code="REQUIRED_FIELD",
+                    message="Agent ID is required",
+                )
+            )
+        if not card.identity.name:
+            errors.append(
+                CardValidationError(
+                    field="identity.name",
+                    error_code="REQUIRED_FIELD",
+                    message="Agent name is required",
+                )
+            )
+        if not card.identity.version:
+            errors.append(
+                CardValidationError(
+                    field="identity.version",
+                    error_code="REQUIRED_FIELD",
+                    message="Agent version is required",
+                )
+            )
+
+        # Validate protocols
+        if not card.supported_protocols:
+            errors.append(
+                CardValidationError(
+                    field="supported_protocols",
+                    error_code="EMPTY_LIST",
+                    message="At least one protocol must be supported",
+                )
+            )
+
+        # Validate endpoints
+        if not card.endpoints:
+            errors.append(
+                CardValidationError(
+                    field="endpoints",
+                    error_code="EMPTY_LIST",
+                    message="At least one endpoint must be defined",
+                )
+            )
+
+        primary_endpoints = [
+            e for e in card.endpoints if e.endpoint_type == EndpointType.PRIMARY
+        ]
+        if not primary_endpoints:
+            warnings.append(
+                CardValidationWarning(
+                    field="endpoints",
+                    warning_code="NO_PRIMARY_ENDPOINT",
+                    message="No primary endpoint defined",
+                    suggestion="Consider marking one endpoint as PRIMARY",
+                )
+            )
+
+        # Check for expired compliance tags
+        for i, tag in enumerate(card.compliance_tags):
+            if tag.is_expired():
+                warnings.append(
+                    CardValidationWarning(
+                        field=f"compliance_tags[{i}]",
+                        warning_code="EXPIRED_CERTIFICATION",
+                        message=f"{tag.standard.value} certification has expired",
+                        suggestion="Renew certification or remove expired tag",
+                    )
+                )
+
+        # Check A2A compliance
+        a2a_compliant = (
+            len(errors) == 0
+            and card.supports_protocol(ProtocolType.A2A)
+            and any(e.endpoint_type == EndpointType.PRIMARY for e in card.endpoints)
+        )
+
+        # Check MCP compliance
+        mcp_compliant = len(errors) == 0 and card.supports_protocol(ProtocolType.MCP)
+
+        return CardValidationResult(
+            valid=len(errors) == 0,
+            errors=errors,
+            warnings=warnings,
+            a2a_compliant=a2a_compliant,
+            mcp_compliant=mcp_compliant,
+        )
+
+
+class AgentCardSerializer:
+    """Serializer for AgentCard to/from JSON."""
+
+    @staticmethod
+    def to_json(card: AgentCard, indent: int | None = 2) -> str:
+        """Serialize AgentCard to JSON string."""
+        return card.to_json(indent=indent)
+
+    @staticmethod
+    def to_dict(card: AgentCard) -> dict[str, Any]:
+        """Serialize AgentCard to dictionary."""
+        return card.to_dict()
+
+    @staticmethod
+    def to_a2a_format(card: AgentCard) -> dict[str, Any]:
+        """
+        Serialize to A2A-compatible format.
+
+        This matches the Google A2A protocol specification.
+        """
+        base = card.to_dict()
+        # A2A specific formatting
+        a2a_format = {
+            "agentCard": {
+                "version": card.card_version,
+                "agent": base["identity"],
+                "capabilities": base["capabilities"],
+                "protocols": base["supported_protocols"],
+                "endpoints": base["endpoints"],
+            }
+        }
+        if "compliance_tags" in base:
+            a2a_format["agentCard"]["compliance"] = base["compliance_tags"]
+        if "data_handling" in base:
+            a2a_format["agentCard"]["dataHandling"] = base["data_handling"]
+        if "trust_requirements" in base:
+            a2a_format["agentCard"]["trustRequirements"] = base["trust_requirements"]
+
+        return a2a_format
+
+    @staticmethod
+    def to_well_known_format(
+        cards: list[AgentCard], base_url: str
+    ) -> WellKnownAgentDescriptions:
+        """Create well-known agent descriptions response."""
+        summaries = [
+            AgentCardSummary.from_card(
+                card, f"{base_url}/agents/{card.identity.agent_id}"
+            )
+            for card in cards
+        ]
+        return WellKnownAgentDescriptions(
+            agents=summaries,
+            total_count=len(summaries),
+        )
+
+
+def negotiate_protocol(
+    card: AgentCard, request: ProtocolNegotiationRequest
+) -> ProtocolNegotiationResult:
+    """
+    Negotiate communication protocol between client and agent.
+
+    Returns the best matching protocol and endpoint.
+    """
+    # Get protocols supported by both client and agent
+    agent_protocols = {p.protocol: p for p in card.supported_protocols}
+    client_protocols = {p.protocol: p for p in request.client_protocols}
+
+    common_protocols = set(agent_protocols.keys()) & set(client_protocols.keys())
+
+    if not common_protocols:
+        return ProtocolNegotiationResult.failed(
+            request_id=request.request_id,
+            reason="No common protocols found between client and agent",
+        )
+
+    # Check if preferred protocol is available
+    selected: SupportedProtocol | None = None
+    if request.preferred_protocol and request.preferred_protocol in common_protocols:
+        selected = agent_protocols[request.preferred_protocol]
+    else:
+        # Priority order: A2A > MCP > GRPC > OPENAPI > others
+        priority = [
+            ProtocolType.A2A,
+            ProtocolType.MCP,
+            ProtocolType.GRPC,
+            ProtocolType.OPENAPI,
+        ]
+        for proto in priority:
+            if proto in common_protocols:
+                selected = agent_protocols[proto]
+                break
+        if not selected:
+            # Just pick one from common
+            selected = agent_protocols[next(iter(common_protocols))]
+
+    # Find matching endpoint
+    selected_endpoint: CardEndpoint | None = None
+    for endpoint in card.endpoints:
+        if endpoint.protocol == selected.protocol:
+            if endpoint.endpoint_type == EndpointType.PRIMARY:
+                selected_endpoint = endpoint
+                break
+            elif selected_endpoint is None:
+                selected_endpoint = endpoint
+
+    if not selected_endpoint:
+        return ProtocolNegotiationResult.failed(
+            request_id=request.request_id,
+            reason=f"No endpoint found for protocol {selected.protocol.value}",
+        )
+
+    # Collect fallbacks
+    fallbacks = [
+        agent_protocols[p]
+        for p in common_protocols
+        if p != selected.protocol and not agent_protocols[p].deprecated
+    ]
+
+    return ProtocolNegotiationResult.successful(
+        request_id=request.request_id,
+        protocol=selected,
+        endpoint=selected_endpoint,
+        fallbacks=fallbacks,
+    )

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -1,0 +1,845 @@
+"""
+Tests for Agent Card Schema (A2A-compatible)
+
+Issue #54 - Phase 3: Agent-to-Agent Interface Negotiation
+"""
+
+import json
+import pytest
+from datetime import datetime, timezone, timedelta
+
+from src.lui_simulator.agent_types import (
+    AgentIdentity,
+    AgentCapability,
+    CapabilityType,
+    SchemaDefinition,
+)
+from src.agent_negotiation.agent_card import (
+    # Protocol types
+    ProtocolType,
+    SupportedProtocol,
+    # Endpoint types
+    EndpointType,
+    AuthMethod,
+    AuthConfig,
+    CardEndpoint,
+    RetryPolicy,
+    # Compliance types
+    ComplianceStandard,
+    ComplianceTag,
+    DataHandlingPolicy,
+    # Agent Card
+    AgentCard,
+    AgentCardSummary,
+    # Discovery types
+    WellKnownAgentDescriptions,
+    AgentCardRequest,
+    AgentCardResponse,
+    ProtocolNegotiationRequest,
+    ProtocolNegotiationResult,
+    # Validation
+    CardValidationError,
+    CardValidationWarning,
+    # Utilities
+    AgentCardBuilder,
+    AgentCardValidator,
+    AgentCardSerializer,
+    negotiate_protocol,
+)
+
+
+# ============================================
+# Test Fixtures
+# ============================================
+
+
+@pytest.fixture
+def sample_identity() -> AgentIdentity:
+    """Create a sample agent identity."""
+    return AgentIdentity.create(
+        name="TestAgent",
+        version="1.0.0",
+        description="A test agent for unit tests",
+        provider="acme",
+        trust_domain="example.com",
+    )
+
+
+@pytest.fixture
+def sample_capability() -> AgentCapability:
+    """Create a sample capability."""
+    return AgentCapability.create(
+        name="search",
+        description="Search for information",
+        capability_type=CapabilityType.QUERY,
+        input_schema=SchemaDefinition.string(description="Search query"),
+        output_schema=SchemaDefinition.string(description="Search results"),
+    )
+
+
+@pytest.fixture
+def sample_protocol() -> SupportedProtocol:
+    """Create a sample protocol."""
+    return SupportedProtocol(
+        protocol=ProtocolType.A2A,
+        version="1.0.0",
+        uri="https://a2a.dev/spec/1.0",
+    )
+
+
+@pytest.fixture
+def sample_endpoint() -> CardEndpoint:
+    """Create a sample endpoint."""
+    return CardEndpoint(
+        endpoint_type=EndpointType.PRIMARY,
+        url="https://api.example.com/v1",
+        protocol=ProtocolType.A2A,
+        auth_config=AuthConfig(method=AuthMethod.BEARER_TOKEN),
+        timeout_ms=30000,
+    )
+
+
+@pytest.fixture
+def sample_card(
+    sample_identity: AgentIdentity,
+    sample_capability: AgentCapability,
+    sample_protocol: SupportedProtocol,
+    sample_endpoint: CardEndpoint,
+) -> AgentCard:
+    """Create a sample agent card."""
+    return AgentCard(
+        identity=sample_identity,
+        capabilities=[sample_capability],
+        supported_protocols=[sample_protocol],
+        endpoints=[sample_endpoint],
+        compliance_tags=[
+            ComplianceTag(standard=ComplianceStandard.GDPR, certified=True)
+        ],
+    )
+
+
+# ============================================
+# Test Protocol Types
+# ============================================
+
+
+class TestProtocolType:
+    """Test ProtocolType enum."""
+
+    def test_protocol_values(self) -> None:
+        """Test protocol type values."""
+        assert ProtocolType.A2A.value == "a2a"
+        assert ProtocolType.MCP.value == "mcp"
+        assert ProtocolType.OPENAPI.value == "openapi"
+        assert ProtocolType.JSON_RPC.value == "json_rpc"
+        assert ProtocolType.GRPC.value == "grpc"
+
+    def test_supported_protocol_creation(self) -> None:
+        """Test creating a supported protocol."""
+        protocol = SupportedProtocol(
+            protocol=ProtocolType.A2A,
+            version="1.0.0",
+            uri="https://a2a.dev/spec",
+            extensions=["streaming"],
+        )
+        assert protocol.protocol == ProtocolType.A2A
+        assert protocol.version == "1.0.0"
+        assert protocol.uri == "https://a2a.dev/spec"
+        assert protocol.extensions == ["streaming"]
+        assert protocol.deprecated is False
+
+    def test_supported_protocol_to_dict(self) -> None:
+        """Test protocol serialization."""
+        protocol = SupportedProtocol(
+            protocol=ProtocolType.MCP,
+            version="2.0.0",
+            deprecated=True,
+        )
+        d = protocol.to_dict()
+        assert d["protocol"] == "mcp"
+        assert d["version"] == "2.0.0"
+        assert d["deprecated"] is True
+
+
+# ============================================
+# Test Endpoint Types
+# ============================================
+
+
+class TestEndpointTypes:
+    """Test endpoint-related types."""
+
+    def test_endpoint_type_values(self) -> None:
+        """Test endpoint type values."""
+        assert EndpointType.PRIMARY.value == "primary"
+        assert EndpointType.FALLBACK.value == "fallback"
+        assert EndpointType.HEALTH_CHECK.value == "health_check"
+        assert EndpointType.DISCOVERY.value == "discovery"
+
+    def test_auth_method_values(self) -> None:
+        """Test auth method values."""
+        assert AuthMethod.NONE.value == "none"
+        assert AuthMethod.API_KEY.value == "api_key"
+        assert AuthMethod.BEARER_TOKEN.value == "bearer_token"
+        assert AuthMethod.MTLS.value == "mtls"
+        assert AuthMethod.OAUTH2.value == "oauth2"
+
+    def test_auth_config_creation(self) -> None:
+        """Test creating auth config."""
+        config = AuthConfig(
+            method=AuthMethod.OAUTH2,
+            token_endpoint="https://auth.example.com/token",
+            scopes=["read", "write"],
+            audience="api.example.com",
+        )
+        assert config.method == AuthMethod.OAUTH2
+        assert config.scopes == ["read", "write"]
+
+    def test_auth_config_to_dict(self) -> None:
+        """Test auth config serialization."""
+        config = AuthConfig(
+            method=AuthMethod.API_KEY, header_name="X-API-Key"
+        )
+        d = config.to_dict()
+        assert d["method"] == "api_key"
+        assert d["header_name"] == "X-API-Key"
+
+    def test_retry_policy_defaults(self) -> None:
+        """Test retry policy defaults."""
+        policy = RetryPolicy()
+        assert policy.max_retries == 3
+        assert policy.initial_backoff_ms == 100
+        assert policy.max_backoff_ms == 10000
+        assert policy.backoff_multiplier == 2.0
+        assert 429 in policy.retryable_status_codes
+        assert 503 in policy.retryable_status_codes
+
+    def test_card_endpoint_creation(self) -> None:
+        """Test creating a card endpoint."""
+        endpoint = CardEndpoint(
+            endpoint_type=EndpointType.PRIMARY,
+            url="https://api.example.com",
+            protocol=ProtocolType.A2A,
+            timeout_ms=5000,
+        )
+        assert endpoint.endpoint_type == EndpointType.PRIMARY
+        assert endpoint.url == "https://api.example.com"
+        assert endpoint.timeout_ms == 5000
+
+    def test_card_endpoint_to_dict(self) -> None:
+        """Test endpoint serialization."""
+        endpoint = CardEndpoint(
+            endpoint_type=EndpointType.HEALTH_CHECK,
+            url="https://api.example.com/health",
+            protocol=ProtocolType.OPENAPI,
+            auth_config=AuthConfig(method=AuthMethod.NONE),
+        )
+        d = endpoint.to_dict()
+        assert d["endpoint_type"] == "health_check"
+        assert d["url"] == "https://api.example.com/health"
+        assert d["protocol"] == "openapi"
+        assert d["auth_config"]["method"] == "none"
+
+
+# ============================================
+# Test Compliance Types
+# ============================================
+
+
+class TestComplianceTypes:
+    """Test compliance-related types."""
+
+    def test_compliance_standard_values(self) -> None:
+        """Test compliance standard values."""
+        assert ComplianceStandard.GDPR.value == "gdpr"
+        assert ComplianceStandard.HIPAA.value == "hipaa"
+        assert ComplianceStandard.SOC2.value == "soc2"
+        assert ComplianceStandard.ISO27001.value == "iso27001"
+        assert ComplianceStandard.PCI_DSS.value == "pci_dss"
+
+    def test_compliance_tag_creation(self) -> None:
+        """Test creating a compliance tag."""
+        tag = ComplianceTag(
+            standard=ComplianceStandard.SOC2_TYPE2,
+            certified=True,
+            certificate_url="https://example.com/cert.pdf",
+            auditor="Big4 Firm",
+        )
+        assert tag.standard == ComplianceStandard.SOC2_TYPE2
+        assert tag.certified is True
+        assert tag.auditor == "Big4 Firm"
+
+    def test_compliance_tag_expiry_check_not_expired(self) -> None:
+        """Test compliance tag is not expired."""
+        future_date = (datetime.now(timezone.utc) + timedelta(days=365)).isoformat()
+        tag = ComplianceTag(
+            standard=ComplianceStandard.GDPR,
+            expiry_date=future_date,
+        )
+        assert tag.is_expired() is False
+
+    def test_compliance_tag_expiry_check_expired(self) -> None:
+        """Test compliance tag is expired."""
+        past_date = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+        tag = ComplianceTag(
+            standard=ComplianceStandard.GDPR,
+            expiry_date=past_date,
+        )
+        assert tag.is_expired() is True
+
+    def test_compliance_tag_no_expiry(self) -> None:
+        """Test compliance tag without expiry date."""
+        tag = ComplianceTag(standard=ComplianceStandard.GDPR)
+        assert tag.is_expired() is False
+
+    def test_data_handling_policy_creation(self) -> None:
+        """Test creating data handling policy."""
+        policy = DataHandlingPolicy(
+            encryption_at_rest=True,
+            encryption_in_transit=True,
+            audit_logging=True,
+            data_residency=["US", "EU"],
+            data_retention_days=90,
+        )
+        assert policy.encryption_at_rest is True
+        assert policy.data_residency == ["US", "EU"]
+        assert policy.data_retention_days == 90
+
+
+# ============================================
+# Test Agent Card
+# ============================================
+
+
+class TestAgentCard:
+    """Test AgentCard class."""
+
+    def test_agent_card_creation(self, sample_card: AgentCard) -> None:
+        """Test creating an agent card."""
+        assert sample_card.identity.name == "TestAgent"
+        assert len(sample_card.capabilities) == 1
+        assert len(sample_card.supported_protocols) == 1
+        assert len(sample_card.endpoints) == 1
+        assert sample_card.card_version == "1.0.0"
+
+    def test_get_primary_endpoint(self, sample_card: AgentCard) -> None:
+        """Test getting primary endpoint."""
+        endpoint = sample_card.get_primary_endpoint()
+        assert endpoint is not None
+        assert endpoint.endpoint_type == EndpointType.PRIMARY
+
+    def test_get_discovery_endpoint_none(self, sample_card: AgentCard) -> None:
+        """Test getting discovery endpoint when not present."""
+        endpoint = sample_card.get_discovery_endpoint()
+        assert endpoint is None
+
+    def test_supports_protocol(self, sample_card: AgentCard) -> None:
+        """Test protocol support check."""
+        assert sample_card.supports_protocol(ProtocolType.A2A) is True
+        assert sample_card.supports_protocol(ProtocolType.MCP) is False
+
+    def test_get_protocol(self, sample_card: AgentCard) -> None:
+        """Test getting protocol details."""
+        protocol = sample_card.get_protocol(ProtocolType.A2A)
+        assert protocol is not None
+        assert protocol.version == "1.0.0"
+
+    def test_is_compliant_with(self, sample_card: AgentCard) -> None:
+        """Test compliance check."""
+        assert sample_card.is_compliant_with(ComplianceStandard.GDPR) is True
+        assert sample_card.is_compliant_with(ComplianceStandard.HIPAA) is False
+
+    def test_get_capability(self, sample_card: AgentCard) -> None:
+        """Test getting capability by ID."""
+        cap = sample_card.capabilities[0]
+        found = sample_card.get_capability(cap.capability_id)
+        assert found is not None
+        assert found.name == "search"
+
+    def test_to_dict(self, sample_card: AgentCard) -> None:
+        """Test card to dictionary conversion."""
+        d = sample_card.to_dict()
+        assert d["card_version"] == "1.0.0"
+        assert d["identity"]["name"] == "TestAgent"
+        assert len(d["capabilities"]) == 1
+        assert len(d["supported_protocols"]) == 1
+        assert len(d["endpoints"]) == 1
+
+    def test_to_json(self, sample_card: AgentCard) -> None:
+        """Test card to JSON conversion."""
+        json_str = sample_card.to_json()
+        parsed = json.loads(json_str)
+        assert parsed["card_version"] == "1.0.0"
+        assert parsed["identity"]["name"] == "TestAgent"
+
+    def test_compute_hash(self, sample_card: AgentCard) -> None:
+        """Test card hash computation."""
+        hash1 = sample_card.compute_hash()
+        hash2 = sample_card.compute_hash()
+        assert hash1 == hash2
+        assert len(hash1) == 64  # SHA-256 hex
+
+
+# ============================================
+# Test Agent Card Summary
+# ============================================
+
+
+class TestAgentCardSummary:
+    """Test AgentCardSummary class."""
+
+    def test_from_card(self, sample_card: AgentCard) -> None:
+        """Test creating summary from card."""
+        summary = AgentCardSummary.from_card(
+            sample_card, "https://example.com/agents/testagent"
+        )
+        assert summary.agent_id == sample_card.identity.agent_id
+        assert summary.name == "TestAgent"
+        assert summary.capability_count == 1
+        assert ProtocolType.A2A in summary.protocols
+        assert ComplianceStandard.GDPR in summary.compliance_standards
+
+    def test_summary_to_dict(self, sample_card: AgentCard) -> None:
+        """Test summary serialization."""
+        summary = AgentCardSummary.from_card(
+            sample_card, "https://example.com/agents/testagent"
+        )
+        d = summary.to_dict()
+        assert d["name"] == "TestAgent"
+        assert d["capability_count"] == 1
+        assert "a2a" in d["protocols"]
+
+
+# ============================================
+# Test Well-Known Discovery
+# ============================================
+
+
+class TestWellKnownDiscovery:
+    """Test well-known discovery types."""
+
+    def test_well_known_agent_descriptions(self, sample_card: AgentCard) -> None:
+        """Test well-known agent descriptions."""
+        summary = AgentCardSummary.from_card(sample_card, "https://example.com")
+        descriptions = WellKnownAgentDescriptions(
+            agents=[summary],
+            total_count=1,
+        )
+        assert descriptions.total_count == 1
+        assert len(descriptions.agents) == 1
+        assert descriptions.schema_version == "1.0.0"
+
+    def test_well_known_to_json(self, sample_card: AgentCard) -> None:
+        """Test well-known to JSON."""
+        summary = AgentCardSummary.from_card(sample_card, "https://example.com")
+        descriptions = WellKnownAgentDescriptions(agents=[summary], total_count=1)
+        json_str = descriptions.to_json()
+        parsed = json.loads(json_str)
+        assert parsed["total_count"] == 1
+        assert len(parsed["agents"]) == 1
+
+    def test_agent_card_request(self) -> None:
+        """Test agent card request creation."""
+        request = AgentCardRequest(
+            agent_id="urn:agent:acme:test:1.0.0",
+            include_capabilities=True,
+        )
+        assert request.agent_id == "urn:agent:acme:test:1.0.0"
+        assert request.include_capabilities is True
+        assert request.request_id is not None
+
+    def test_agent_card_response_success(self, sample_card: AgentCard) -> None:
+        """Test successful agent card response."""
+        response = AgentCardResponse.success(
+            request_id="req-123",
+            card=sample_card,
+            cached=True,
+        )
+        assert response.found is True
+        assert response.agent_card is not None
+        assert response.cached is True
+        assert response.error is None
+
+    def test_agent_card_response_not_found(self) -> None:
+        """Test not-found agent card response."""
+        response = AgentCardResponse.not_found(
+            request_id="req-456",
+            agent_id="unknown-agent",
+        )
+        assert response.found is False
+        assert response.agent_card is None
+        assert response.error is not None
+        assert response.error.error_code == "AGENT_NOT_FOUND"
+
+
+# ============================================
+# Test Protocol Negotiation
+# ============================================
+
+
+class TestProtocolNegotiation:
+    """Test protocol negotiation."""
+
+    def test_successful_negotiation(self, sample_card: AgentCard) -> None:
+        """Test successful protocol negotiation."""
+        request = ProtocolNegotiationRequest(
+            client_protocols=[
+                SupportedProtocol(protocol=ProtocolType.A2A, version="1.0.0"),
+                SupportedProtocol(protocol=ProtocolType.MCP, version="1.0.0"),
+            ],
+        )
+        result = negotiate_protocol(sample_card, request)
+        assert result.success is True
+        assert result.selected_protocol is not None
+        assert result.selected_protocol.protocol == ProtocolType.A2A
+        assert result.selected_endpoint is not None
+
+    def test_negotiation_with_preferred_protocol(self, sample_card: AgentCard) -> None:
+        """Test negotiation with preferred protocol."""
+        # Add MCP to the card
+        sample_card.supported_protocols.append(
+            SupportedProtocol(protocol=ProtocolType.MCP, version="1.0.0")
+        )
+        sample_card.endpoints.append(
+            CardEndpoint(
+                endpoint_type=EndpointType.FALLBACK,
+                url="https://api.example.com/mcp",
+                protocol=ProtocolType.MCP,
+            )
+        )
+        request = ProtocolNegotiationRequest(
+            client_protocols=[
+                SupportedProtocol(protocol=ProtocolType.A2A, version="1.0.0"),
+                SupportedProtocol(protocol=ProtocolType.MCP, version="1.0.0"),
+            ],
+            preferred_protocol=ProtocolType.MCP,
+        )
+        result = negotiate_protocol(sample_card, request)
+        assert result.success is True
+        assert result.selected_protocol.protocol == ProtocolType.MCP
+
+    def test_negotiation_no_common_protocols(self, sample_card: AgentCard) -> None:
+        """Test negotiation failure with no common protocols."""
+        request = ProtocolNegotiationRequest(
+            client_protocols=[
+                SupportedProtocol(protocol=ProtocolType.GRAPHQL, version="1.0.0"),
+            ],
+        )
+        result = negotiate_protocol(sample_card, request)
+        assert result.success is False
+        assert result.failure_reason is not None
+        assert "No common protocols" in result.failure_reason
+
+
+# ============================================
+# Test Card Validation
+# ============================================
+
+
+class TestCardValidation:
+    """Test card validation."""
+
+    def test_validate_valid_card(self, sample_card: AgentCard) -> None:
+        """Test validating a valid card."""
+        validator = AgentCardValidator()
+        result = validator.validate(sample_card)
+        assert result.valid is True
+        assert len(result.errors) == 0
+        assert result.a2a_compliant is True
+
+    def test_validate_missing_protocols(
+        self, sample_identity: AgentIdentity, sample_capability: AgentCapability
+    ) -> None:
+        """Test validating card with missing protocols."""
+        card = AgentCard(
+            identity=sample_identity,
+            capabilities=[sample_capability],
+            supported_protocols=[],
+            endpoints=[
+                CardEndpoint(
+                    endpoint_type=EndpointType.PRIMARY,
+                    url="https://example.com",
+                    protocol=ProtocolType.A2A,
+                )
+            ],
+        )
+        validator = AgentCardValidator()
+        result = validator.validate(card)
+        assert result.valid is False
+        assert any(e.error_code == "EMPTY_LIST" for e in result.errors)
+
+    def test_validate_missing_endpoints(
+        self, sample_identity: AgentIdentity, sample_capability: AgentCapability
+    ) -> None:
+        """Test validating card with missing endpoints."""
+        card = AgentCard(
+            identity=sample_identity,
+            capabilities=[sample_capability],
+            supported_protocols=[
+                SupportedProtocol(protocol=ProtocolType.A2A, version="1.0.0")
+            ],
+            endpoints=[],
+        )
+        validator = AgentCardValidator()
+        result = validator.validate(card)
+        assert result.valid is False
+        assert any(e.error_code == "EMPTY_LIST" for e in result.errors)
+
+    def test_validate_expired_compliance(self, sample_card: AgentCard) -> None:
+        """Test validation warns about expired compliance."""
+        past_date = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+        sample_card.compliance_tags.append(
+            ComplianceTag(
+                standard=ComplianceStandard.HIPAA,
+                certified=True,
+                expiry_date=past_date,
+            )
+        )
+        validator = AgentCardValidator()
+        result = validator.validate(sample_card)
+        assert any(w.warning_code == "EXPIRED_CERTIFICATION" for w in result.warnings)
+
+    def test_validate_no_primary_endpoint(
+        self, sample_identity: AgentIdentity, sample_capability: AgentCapability
+    ) -> None:
+        """Test validation warns about missing primary endpoint."""
+        card = AgentCard(
+            identity=sample_identity,
+            capabilities=[sample_capability],
+            supported_protocols=[
+                SupportedProtocol(protocol=ProtocolType.A2A, version="1.0.0")
+            ],
+            endpoints=[
+                CardEndpoint(
+                    endpoint_type=EndpointType.FALLBACK,
+                    url="https://example.com",
+                    protocol=ProtocolType.A2A,
+                )
+            ],
+        )
+        validator = AgentCardValidator()
+        result = validator.validate(card)
+        assert result.valid is True  # Still valid, just a warning
+        assert any(w.warning_code == "NO_PRIMARY_ENDPOINT" for w in result.warnings)
+
+
+# ============================================
+# Test Agent Card Builder
+# ============================================
+
+
+class TestAgentCardBuilder:
+    """Test AgentCardBuilder class."""
+
+    def test_builder_basic_card(
+        self, sample_identity: AgentIdentity, sample_capability: AgentCapability
+    ) -> None:
+        """Test building a basic card."""
+        card = (
+            AgentCardBuilder(sample_identity)
+            .add_capability(sample_capability)
+            .add_protocol(ProtocolType.A2A, "1.0.0")
+            .add_endpoint(
+                EndpointType.PRIMARY,
+                "https://api.example.com",
+                ProtocolType.A2A,
+            )
+            .build()
+        )
+        assert card.identity == sample_identity
+        assert len(card.capabilities) == 1
+        assert len(card.supported_protocols) == 1
+        assert len(card.endpoints) == 1
+
+    def test_builder_with_compliance(
+        self, sample_identity: AgentIdentity, sample_capability: AgentCapability
+    ) -> None:
+        """Test building card with compliance."""
+        card = (
+            AgentCardBuilder(sample_identity)
+            .add_capability(sample_capability)
+            .add_protocol(ProtocolType.A2A, "1.0.0")
+            .add_endpoint(EndpointType.PRIMARY, "https://api.example.com", ProtocolType.A2A)
+            .add_compliance(ComplianceStandard.GDPR)
+            .add_compliance(ComplianceStandard.SOC2_TYPE2)
+            .build()
+        )
+        assert len(card.compliance_tags) == 2
+        assert card.is_compliant_with(ComplianceStandard.GDPR)
+
+    def test_builder_with_data_handling(
+        self, sample_identity: AgentIdentity, sample_capability: AgentCapability
+    ) -> None:
+        """Test building card with data handling."""
+        card = (
+            AgentCardBuilder(sample_identity)
+            .add_capability(sample_capability)
+            .add_protocol(ProtocolType.A2A, "1.0.0")
+            .add_endpoint(EndpointType.PRIMARY, "https://api.example.com", ProtocolType.A2A)
+            .with_data_handling(
+                encryption_at_rest=True,
+                encryption_in_transit=True,
+                data_residency=["US", "EU"],
+            )
+            .build()
+        )
+        assert card.data_handling is not None
+        assert card.data_handling.encryption_at_rest is True
+        assert card.data_handling.data_residency == ["US", "EU"]
+
+    def test_builder_fails_without_protocols(
+        self, sample_identity: AgentIdentity
+    ) -> None:
+        """Test builder fails without protocols."""
+        builder = AgentCardBuilder(sample_identity).add_endpoint(
+            EndpointType.PRIMARY, "https://api.example.com", ProtocolType.A2A
+        )
+        with pytest.raises(ValueError, match="At least one protocol"):
+            builder.build()
+
+    def test_builder_fails_without_endpoints(
+        self, sample_identity: AgentIdentity
+    ) -> None:
+        """Test builder fails without endpoints."""
+        builder = AgentCardBuilder(sample_identity).add_protocol(
+            ProtocolType.A2A, "1.0.0"
+        )
+        with pytest.raises(ValueError, match="At least one endpoint"):
+            builder.build()
+
+
+# ============================================
+# Test Serializer
+# ============================================
+
+
+class TestAgentCardSerializer:
+    """Test AgentCardSerializer class."""
+
+    def test_to_json(self, sample_card: AgentCard) -> None:
+        """Test serializing to JSON."""
+        json_str = AgentCardSerializer.to_json(sample_card)
+        parsed = json.loads(json_str)
+        assert parsed["card_version"] == "1.0.0"
+
+    def test_to_dict(self, sample_card: AgentCard) -> None:
+        """Test serializing to dict."""
+        d = AgentCardSerializer.to_dict(sample_card)
+        assert d["card_version"] == "1.0.0"
+
+    def test_to_a2a_format(self, sample_card: AgentCard) -> None:
+        """Test serializing to A2A format."""
+        a2a = AgentCardSerializer.to_a2a_format(sample_card)
+        assert "agentCard" in a2a
+        assert a2a["agentCard"]["version"] == "1.0.0"
+        assert "agent" in a2a["agentCard"]
+        assert "capabilities" in a2a["agentCard"]
+        assert "protocols" in a2a["agentCard"]
+
+    def test_to_well_known_format(self, sample_card: AgentCard) -> None:
+        """Test creating well-known format."""
+        descriptions = AgentCardSerializer.to_well_known_format(
+            [sample_card], "https://example.com"
+        )
+        assert descriptions.total_count == 1
+        assert len(descriptions.agents) == 1
+        assert "testagent" in descriptions.agents[0].discovery_url.lower()
+
+
+# ============================================
+# Test Edge Cases
+# ============================================
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_empty_capabilities_list(
+        self, sample_identity: AgentIdentity
+    ) -> None:
+        """Test card with no capabilities."""
+        card = AgentCard(
+            identity=sample_identity,
+            capabilities=[],
+            supported_protocols=[
+                SupportedProtocol(protocol=ProtocolType.A2A, version="1.0.0")
+            ],
+            endpoints=[
+                CardEndpoint(
+                    endpoint_type=EndpointType.PRIMARY,
+                    url="https://api.example.com",
+                    protocol=ProtocolType.A2A,
+                )
+            ],
+        )
+        assert len(card.capabilities) == 0
+        assert card.get_capability("nonexistent") is None
+
+    def test_multiple_endpoints_same_type(
+        self, sample_identity: AgentIdentity
+    ) -> None:
+        """Test card with multiple endpoints of same type."""
+        card = AgentCard(
+            identity=sample_identity,
+            capabilities=[],
+            supported_protocols=[
+                SupportedProtocol(protocol=ProtocolType.A2A, version="1.0.0")
+            ],
+            endpoints=[
+                CardEndpoint(
+                    endpoint_type=EndpointType.PRIMARY,
+                    url="https://api1.example.com",
+                    protocol=ProtocolType.A2A,
+                ),
+                CardEndpoint(
+                    endpoint_type=EndpointType.PRIMARY,
+                    url="https://api2.example.com",
+                    protocol=ProtocolType.A2A,
+                ),
+            ],
+        )
+        # Should return first primary
+        primary = card.get_primary_endpoint()
+        assert primary.url == "https://api1.example.com"
+
+    def test_protocol_negotiation_result_factories(self) -> None:
+        """Test protocol negotiation result factory methods."""
+        success = ProtocolNegotiationResult.successful(
+            request_id="req-1",
+            protocol=SupportedProtocol(protocol=ProtocolType.A2A, version="1.0.0"),
+            endpoint=CardEndpoint(
+                endpoint_type=EndpointType.PRIMARY,
+                url="https://example.com",
+                protocol=ProtocolType.A2A,
+            ),
+        )
+        assert success.success is True
+        assert success.failure_reason is None
+
+        failed = ProtocolNegotiationResult.failed(
+            request_id="req-2",
+            reason="No compatible protocol",
+        )
+        assert failed.success is False
+        assert failed.failure_reason == "No compatible protocol"
+
+    def test_validation_error_structure(self) -> None:
+        """Test validation error structure."""
+        error = CardValidationError(
+            field="identity.agent_id",
+            error_code="REQUIRED_FIELD",
+            message="Agent ID is required",
+        )
+        assert error.field == "identity.agent_id"
+        assert error.error_code == "REQUIRED_FIELD"
+
+    def test_validation_warning_structure(self) -> None:
+        """Test validation warning structure."""
+        warning = CardValidationWarning(
+            field="endpoints",
+            warning_code="NO_PRIMARY_ENDPOINT",
+            message="No primary endpoint",
+            suggestion="Add a primary endpoint",
+        )
+        assert warning.field == "endpoints"
+        assert warning.suggestion == "Add a primary endpoint"


### PR DESCRIPTION
## Summary
- Implements Task 3.2: Agent Card Schema from Phase 3 (Agent-to-Agent Interface Negotiation)
- Creates comprehensive agent card types compatible with Google A2A protocol
- Adds protocol negotiation, compliance tracking, and card validation utilities

## Changes

### BAML Types (`baml_src/agent_card.baml`)
- **Protocol Types**: `ProtocolType` enum (A2A, MCP, OpenAPI, JSON-RPC, gRPC, GraphQL, WebSocket, Custom), `SupportedProtocol` with versioning
- **Endpoint Types**: `EndpointType`, `AuthMethod`, `AuthConfig`, `CardEndpoint`, `RetryPolicy`
- **Compliance Types**: `ComplianceStandard` enum (GDPR, HIPAA, SOC2, ISO27001, PCI-DSS, FedRAMP, etc.), `ComplianceTag`, `DataHandlingPolicy`
- **Agent Card**: `AgentCard` as primary advertisement format, `AgentCardSummary` for lightweight discovery
- **Discovery**: `WellKnownAgentDescriptions` for `.well-known/agent-descriptions` endpoint
- **Negotiation**: `ProtocolNegotiationRequest`, `ProtocolNegotiationResult`
- **Validation**: `CardValidationResult`, `CardValidationError`, `CardValidationWarning`

### Python Implementation (`src/agent_negotiation/`)
- Full dataclass implementations with `to_dict()`/`to_json()` serialization
- `AgentCardBuilder` - Fluent builder pattern for card construction
- `AgentCardValidator` - Card validation with A2A/MCP compliance checking
- `AgentCardSerializer` - Multiple output formats (JSON, dict, A2A, well-known)
- `negotiate_protocol()` - Protocol selection between agents

### Tests (`tests/test_agent_card.py`)
- 55 comprehensive tests covering all types
- Protocol negotiation success/failure scenarios
- Validation with errors and warnings
- Builder pattern and serialization tests

## Test Plan
- [x] All 55 new tests pass
- [x] Full test suite (1268 tests) passes
- [x] Ruff linting passes

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)