### PR TITLE
feat(registry): Implement capability registry and discovery service (#55)

### DIFF
--- a/baml_src/capability_discovery.baml
+++ b/baml_src/capability_discovery.baml
@@ -1,0 +1,178 @@
+// Capability Registry & Discovery Service
+// Agent discovery and capability matching for Phase 3 agent negotiation
+// Issue #55 - Phase 3: Agent-to-Agent Interface Negotiation
+
+// Dependencies:
+// - AgentIdentity from agent_identity.baml
+// - AgentCard from agent_card.baml
+
+// ============================================
+// Discovery Constraints
+// ============================================
+
+/// Types of constraints for agent discovery
+enum ConstraintType {
+  CAPABILITY @description("Must have specific capability")
+  PROTOCOL @description("Must support specific protocol")
+  COMPLIANCE @description("Must meet compliance standard")
+  TRUST_LEVEL @description("Must meet minimum trust level")
+  REGION @description("Must be in specific region")
+  PROVIDER @description("Must be from specific provider")
+  VERSION @description("Must meet version requirements")
+  PERFORMANCE @description("Must meet performance criteria")
+}
+
+/// Comparison operators for constraint matching
+enum ConstraintOperator {
+  EQUALS @description("Exact match")
+  NOT_EQUALS @description("Must not match")
+  GREATER_THAN @description("Greater than value")
+  LESS_THAN @description("Less than value")
+  GREATER_OR_EQUAL @description("Greater than or equal")
+  LESS_OR_EQUAL @description("Less than or equal")
+  CONTAINS @description("Value contains substring")
+  IN @description("Value is in list")
+  NOT_IN @description("Value is not in list")
+  REGEX @description("Value matches regex pattern")
+}
+
+/// A constraint for filtering agents in discovery
+class DiscoveryConstraint {
+  constraint_type ConstraintType @description("Type of constraint")
+  field string @description("Field path to check (e.g., 'identity.provider')")
+  operator ConstraintOperator @description("Comparison operator")
+  value string @description("Value to compare against")
+  weight float? @description("Weight for scoring (0.0-1.0)")
+  required bool @description("Whether constraint is required vs preferred")
+}
+
+// ============================================
+// Discovery Request/Response
+// ============================================
+
+/// Source of discovery results
+enum DiscoverySource {
+  REGISTRY @description("Local capability registry")
+  CACHE @description("Cached results from previous discovery")
+  PEER_DISCOVERY @description("Discovered via peer agents")
+  LOCAL @description("Local/embedded agents")
+  WELL_KNOWN @description("From .well-known discovery endpoint")
+}
+
+/// Request to discover agents with specific capabilities
+class DiscoveryRequest {
+  request_id string @description("Unique request identifier")
+  requester AgentIdentity @description("Identity of requesting agent")
+  required_capabilities string[] @description("Capability IDs that must be present")
+  optional_capabilities string[]? @description("Capability IDs that are nice to have")
+  constraints DiscoveryConstraint[] @description("Additional filtering constraints")
+  max_results int @description("Maximum number of results to return")
+  timeout_ms int? @description("Request timeout in milliseconds")
+  include_inactive bool @description("Whether to include inactive/unhealthy agents")
+  requested_at string @description("ISO 8601 timestamp of request")
+}
+
+/// A matching agent with relevance scoring
+class AgentMatch {
+  agent AgentCard @description("The matched agent's card")
+  match_score float @description("Overall match score (0.0-1.0)")
+  capability_coverage float @description("Percentage of required capabilities matched")
+  constraint_satisfaction float @description("Percentage of constraints satisfied")
+  compatibility_notes string[]? @description("Notes about compatibility considerations")
+  matched_capabilities string[] @description("List of matched capability IDs")
+  missing_capabilities string[]? @description("List of missing required capabilities")
+}
+
+/// Response from capability discovery
+class DiscoveryResponse {
+  request_id string @description("ID of the original request")
+  agents AgentMatch[] @description("List of matched agents, sorted by score")
+  total_count int @description("Total number of matching agents")
+  returned_count int @description("Number of agents returned (may be limited)")
+  discovery_time_ms int @description("Time taken for discovery in milliseconds")
+  source DiscoverySource @description("Source of the discovery results")
+  cached bool @description("Whether results are from cache")
+  cache_expires_at string? @description("ISO 8601 timestamp when cache expires")
+}
+
+// ============================================
+// Registry Operations
+// ============================================
+
+/// Request to register an agent in the registry
+class RegistrationRequest {
+  request_id string @description("Unique request identifier")
+  agent_card AgentCard @description("Agent card to register")
+  ttl_seconds int @description("Time-to-live for registration")
+  tags string[]? @description("Additional tags for categorization")
+  priority int? @description("Registration priority (higher = preferred)")
+}
+
+/// Response from agent registration
+class RegistrationResponse {
+  request_id string @description("ID of the original request")
+  success bool @description("Whether registration succeeded")
+  registration_id string? @description("Unique registration ID if successful")
+  expires_at string? @description("ISO 8601 timestamp when registration expires")
+  error RegistrationError? @description("Error details if registration failed")
+}
+
+/// Error during registration
+class RegistrationError {
+  error_code string @description("Machine-readable error code")
+  message string @description("Human-readable error message")
+  field string? @description("Field that caused the error")
+}
+
+/// Request to update an existing registration
+class UpdateRequest {
+  request_id string @description("Unique request identifier")
+  registration_id string @description("ID of registration to update")
+  agent_card AgentCard @description("Updated agent card")
+  extend_ttl bool @description("Whether to extend TTL")
+  new_ttl_seconds int? @description("New TTL if extending")
+}
+
+/// Request to deregister an agent
+class DeregistrationRequest {
+  request_id string @description("Unique request identifier")
+  registration_id string @description("ID of registration to remove")
+  agent_id string @description("Agent ID for verification")
+  reason string? @description("Reason for deregistration")
+}
+
+/// Response from deregistration
+class DeregistrationResponse {
+  request_id string @description("ID of the original request")
+  success bool @description("Whether deregistration succeeded")
+  message string? @description("Additional information")
+}
+
+// ============================================
+// Registry Status
+// ============================================
+
+/// Health status of the registry
+class RegistryStatus {
+  healthy bool @description("Whether registry is healthy")
+  agent_count int @description("Number of registered agents")
+  capability_count int @description("Number of unique capabilities indexed")
+  last_cleanup string @description("ISO 8601 timestamp of last cleanup")
+  uptime_seconds int @description("Registry uptime in seconds")
+  cache_hit_rate float @description("Cache hit rate (0.0-1.0)")
+}
+
+/// Statistics about a registered capability
+class CapabilityStats {
+  capability_id string @description("Capability identifier")
+  agent_count int @description("Number of agents with this capability")
+  average_version string @description("Average version of capability")
+  protocols ProtocolType[] @description("Protocols supporting this capability")
+}
+
+/// Index entry for fast capability lookup
+class CapabilityIndex {
+  capability_id string @description("Capability identifier")
+  agent_ids string[] @description("IDs of agents with this capability")
+  last_updated string @description("ISO 8601 timestamp of last update")
+}

--- a/src/agent_negotiation/__init__.py
+++ b/src/agent_negotiation/__init__.py
@@ -39,6 +39,30 @@ from .agent_card import (
     AgentCardSerializer,
 )
 
+from .capability_registry import (
+    # Constraint types
+    ConstraintType,
+    ConstraintOperator,
+    DiscoveryConstraint,
+    # Discovery types
+    DiscoverySource,
+    DiscoveryRequest,
+    AgentMatch,
+    DiscoveryResponse,
+    # Registry operations
+    RegistrationRequest,
+    RegistrationError,
+    RegistrationResponse,
+    DeregistrationRequest,
+    DeregistrationResponse,
+    # Registry status
+    RegistryStatus,
+    CapabilityStats,
+    CapabilityIndex,
+    # Registry class
+    CapabilityRegistry,
+)
+
 __all__ = [
     # Protocol types
     "ProtocolType",
@@ -56,7 +80,7 @@ __all__ = [
     # Agent Card
     "AgentCard",
     "AgentCardSummary",
-    # Discovery types
+    # Discovery types (agent_card)
     "WellKnownAgentDescriptions",
     "AgentCardRequest",
     "AgentCardResponse",
@@ -72,4 +96,25 @@ __all__ = [
     "AgentCardBuilder",
     "AgentCardValidator",
     "AgentCardSerializer",
+    # Constraint types
+    "ConstraintType",
+    "ConstraintOperator",
+    "DiscoveryConstraint",
+    # Discovery types (capability_registry)
+    "DiscoverySource",
+    "DiscoveryRequest",
+    "AgentMatch",
+    "DiscoveryResponse",
+    # Registry operations
+    "RegistrationRequest",
+    "RegistrationError",
+    "RegistrationResponse",
+    "DeregistrationRequest",
+    "DeregistrationResponse",
+    # Registry status
+    "RegistryStatus",
+    "CapabilityStats",
+    "CapabilityIndex",
+    # Registry class
+    "CapabilityRegistry",
 ]

--- a/src/agent_negotiation/capability_registry.py
+++ b/src/agent_negotiation/capability_registry.py
@@ -1,0 +1,949 @@
+"""
+Capability Registry & Discovery Service
+
+Agent discovery and capability matching for Phase 3 agent negotiation.
+
+Issue #55 - Phase 3: Agent-to-Agent Interface Negotiation
+"""
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+import re
+import threading
+import time
+import uuid
+
+from src.lui_simulator.agent_types import (
+    AgentIdentity,
+)
+from src.agent_negotiation.agent_card import (
+    AgentCard,
+    ProtocolType,
+)
+
+
+# ============================================
+# Discovery Constraints
+# ============================================
+
+
+class ConstraintType(Enum):
+    """Types of constraints for agent discovery."""
+
+    CAPABILITY = "capability"
+    PROTOCOL = "protocol"
+    COMPLIANCE = "compliance"
+    TRUST_LEVEL = "trust_level"
+    REGION = "region"
+    PROVIDER = "provider"
+    VERSION = "version"
+    PERFORMANCE = "performance"
+
+
+class ConstraintOperator(Enum):
+    """Comparison operators for constraint matching."""
+
+    EQUALS = "equals"
+    NOT_EQUALS = "not_equals"
+    GREATER_THAN = "greater_than"
+    LESS_THAN = "less_than"
+    GREATER_OR_EQUAL = "greater_or_equal"
+    LESS_OR_EQUAL = "less_or_equal"
+    CONTAINS = "contains"
+    IN = "in"
+    NOT_IN = "not_in"
+    REGEX = "regex"
+
+
+@dataclass
+class DiscoveryConstraint:
+    """A constraint for filtering agents in discovery."""
+
+    constraint_type: ConstraintType
+    field: str
+    operator: ConstraintOperator
+    value: str
+    weight: float = 1.0
+    required: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "constraint_type": self.constraint_type.value,
+            "field": self.field,
+            "operator": self.operator.value,
+            "value": self.value,
+            "weight": self.weight,
+            "required": self.required,
+        }
+
+
+# ============================================
+# Discovery Source
+# ============================================
+
+
+class DiscoverySource(Enum):
+    """Source of discovery results."""
+
+    REGISTRY = "registry"
+    CACHE = "cache"
+    PEER_DISCOVERY = "peer_discovery"
+    LOCAL = "local"
+    WELL_KNOWN = "well_known"
+
+
+# ============================================
+# Discovery Request/Response
+# ============================================
+
+
+@dataclass
+class DiscoveryRequest:
+    """Request to discover agents with specific capabilities."""
+
+    requester: AgentIdentity
+    required_capabilities: list[str]
+    constraints: list[DiscoveryConstraint] = field(default_factory=list)
+    optional_capabilities: list[str] = field(default_factory=list)
+    max_results: int = 10
+    timeout_ms: int | None = None
+    include_inactive: bool = False
+    request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    requested_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        # Convert requester to dict, filtering out None values
+        requester_dict = {k: v for k, v in asdict(self.requester).items() if v is not None}
+        result: dict[str, Any] = {
+            "request_id": self.request_id,
+            "requester": requester_dict,
+            "required_capabilities": self.required_capabilities,
+            "constraints": [c.to_dict() for c in self.constraints],
+            "max_results": self.max_results,
+            "include_inactive": self.include_inactive,
+            "requested_at": self.requested_at,
+        }
+        if self.optional_capabilities:
+            result["optional_capabilities"] = self.optional_capabilities
+        if self.timeout_ms:
+            result["timeout_ms"] = self.timeout_ms
+        return result
+
+
+@dataclass
+class AgentMatch:
+    """A matching agent with relevance scoring."""
+
+    agent: AgentCard
+    match_score: float
+    capability_coverage: float
+    constraint_satisfaction: float
+    matched_capabilities: list[str]
+    compatibility_notes: list[str] = field(default_factory=list)
+    missing_capabilities: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "agent": self.agent.to_dict(),
+            "match_score": self.match_score,
+            "capability_coverage": self.capability_coverage,
+            "constraint_satisfaction": self.constraint_satisfaction,
+            "matched_capabilities": self.matched_capabilities,
+        }
+        if self.compatibility_notes:
+            result["compatibility_notes"] = self.compatibility_notes
+        if self.missing_capabilities:
+            result["missing_capabilities"] = self.missing_capabilities
+        return result
+
+
+@dataclass
+class DiscoveryResponse:
+    """Response from capability discovery."""
+
+    request_id: str
+    agents: list[AgentMatch]
+    total_count: int
+    returned_count: int
+    discovery_time_ms: int
+    source: DiscoverySource
+    cached: bool = False
+    cache_expires_at: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "request_id": self.request_id,
+            "agents": [a.to_dict() for a in self.agents],
+            "total_count": self.total_count,
+            "returned_count": self.returned_count,
+            "discovery_time_ms": self.discovery_time_ms,
+            "source": self.source.value,
+            "cached": self.cached,
+        }
+        if self.cache_expires_at:
+            result["cache_expires_at"] = self.cache_expires_at
+        return result
+
+
+# ============================================
+# Registry Operations
+# ============================================
+
+
+@dataclass
+class RegistrationRequest:
+    """Request to register an agent in the registry."""
+
+    agent_card: AgentCard
+    ttl_seconds: int = 3600
+    tags: list[str] = field(default_factory=list)
+    priority: int = 0
+    request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "request_id": self.request_id,
+            "agent_card": self.agent_card.to_dict(),
+            "ttl_seconds": self.ttl_seconds,
+            "priority": self.priority,
+        }
+        if self.tags:
+            result["tags"] = self.tags
+        return result
+
+
+@dataclass
+class RegistrationError:
+    """Error during registration."""
+
+    error_code: str
+    message: str
+    field: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "error_code": self.error_code,
+            "message": self.message,
+        }
+        if self.field:
+            result["field"] = self.field
+        return result
+
+
+@dataclass
+class RegistrationResponse:
+    """Response from agent registration."""
+
+    request_id: str
+    success: bool
+    registration_id: str | None = None
+    expires_at: str | None = None
+    error: RegistrationError | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "request_id": self.request_id,
+            "success": self.success,
+        }
+        if self.registration_id:
+            result["registration_id"] = self.registration_id
+        if self.expires_at:
+            result["expires_at"] = self.expires_at
+        if self.error:
+            result["error"] = self.error.to_dict()
+        return result
+
+    @classmethod
+    def success_response(
+        cls, request_id: str, registration_id: str, expires_at: str
+    ) -> "RegistrationResponse":
+        """Create a successful registration response."""
+        return cls(
+            request_id=request_id,
+            success=True,
+            registration_id=registration_id,
+            expires_at=expires_at,
+        )
+
+    @classmethod
+    def error_response(
+        cls, request_id: str, error_code: str, message: str, field: str | None = None
+    ) -> "RegistrationResponse":
+        """Create an error registration response."""
+        return cls(
+            request_id=request_id,
+            success=False,
+            error=RegistrationError(error_code, message, field),
+        )
+
+
+@dataclass
+class DeregistrationRequest:
+    """Request to deregister an agent."""
+
+    registration_id: str
+    agent_id: str
+    reason: str | None = None
+    request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "request_id": self.request_id,
+            "registration_id": self.registration_id,
+            "agent_id": self.agent_id,
+        }
+        if self.reason:
+            result["reason"] = self.reason
+        return result
+
+
+@dataclass
+class DeregistrationResponse:
+    """Response from deregistration."""
+
+    request_id: str
+    success: bool
+    message: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "request_id": self.request_id,
+            "success": self.success,
+        }
+        if self.message:
+            result["message"] = self.message
+        return result
+
+
+# ============================================
+# Registry Status
+# ============================================
+
+
+@dataclass
+class RegistryStatus:
+    """Health status of the registry."""
+
+    healthy: bool
+    agent_count: int
+    capability_count: int
+    last_cleanup: str
+    uptime_seconds: int
+    cache_hit_rate: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "healthy": self.healthy,
+            "agent_count": self.agent_count,
+            "capability_count": self.capability_count,
+            "last_cleanup": self.last_cleanup,
+            "uptime_seconds": self.uptime_seconds,
+            "cache_hit_rate": self.cache_hit_rate,
+        }
+
+
+@dataclass
+class CapabilityStats:
+    """Statistics about a registered capability."""
+
+    capability_id: str
+    agent_count: int
+    average_version: str
+    protocols: list[ProtocolType]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "capability_id": self.capability_id,
+            "agent_count": self.agent_count,
+            "average_version": self.average_version,
+            "protocols": [p.value for p in self.protocols],
+        }
+
+
+@dataclass
+class CapabilityIndex:
+    """Index entry for fast capability lookup."""
+
+    capability_id: str
+    agent_ids: list[str]
+    last_updated: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "capability_id": self.capability_id,
+            "agent_ids": self.agent_ids,
+            "last_updated": self.last_updated,
+        }
+
+
+# ============================================
+# Registry Entry
+# ============================================
+
+
+@dataclass
+class RegistryEntry:
+    """Internal entry in the capability registry."""
+
+    registration_id: str
+    agent_card: AgentCard
+    expires_at: datetime
+    tags: list[str]
+    priority: int
+    registered_at: datetime
+
+
+# ============================================
+# Capability Registry
+# ============================================
+
+
+class CapabilityRegistry:
+    """
+    In-memory capability registry for agent discovery.
+
+    Provides fast lookups via inverted index by capability.
+    Supports TTL-based expiration and constraint filtering.
+    """
+
+    def __init__(self, cleanup_interval_seconds: int = 60):
+        """Initialize the registry."""
+        self._entries: dict[str, RegistryEntry] = {}
+        self._agent_id_to_reg_id: dict[str, str] = {}
+        self._capability_index: dict[str, set[str]] = {}
+        self._protocol_index: dict[ProtocolType, set[str]] = {}
+        self._provider_index: dict[str, set[str]] = {}
+        self._lock = threading.RLock()
+        self._start_time = datetime.now(timezone.utc)
+        self._last_cleanup = datetime.now(timezone.utc)
+        self._cache_hits = 0
+        self._cache_misses = 0
+        self._cleanup_interval = cleanup_interval_seconds
+
+    def register(
+        self,
+        agent_card: AgentCard,
+        ttl_seconds: int = 3600,
+        tags: list[str] | None = None,
+        priority: int = 0,
+    ) -> RegistrationResponse:
+        """
+        Register an agent card in the registry.
+
+        Args:
+            agent_card: The agent card to register
+            ttl_seconds: Time-to-live in seconds
+            tags: Optional tags for categorization
+            priority: Registration priority (higher = preferred)
+
+        Returns:
+            RegistrationResponse with success status and registration ID
+        """
+        request_id = str(uuid.uuid4())
+
+        # Validate agent card
+        if not agent_card.identity.agent_id:
+            return RegistrationResponse.error_response(
+                request_id, "INVALID_AGENT_ID", "Agent ID is required", "identity.agent_id"
+            )
+
+        with self._lock:
+            # Check for existing registration
+            agent_id = agent_card.identity.agent_id
+            if agent_id in self._agent_id_to_reg_id:
+                # Update existing registration
+                old_reg_id = self._agent_id_to_reg_id[agent_id]
+                self._remove_from_indices(old_reg_id)
+                del self._entries[old_reg_id]
+
+            # Create new registration
+            registration_id = str(uuid.uuid4())
+            now = datetime.now(timezone.utc)
+            expires_at = datetime.fromtimestamp(
+                now.timestamp() + ttl_seconds, tz=timezone.utc
+            )
+
+            entry = RegistryEntry(
+                registration_id=registration_id,
+                agent_card=agent_card,
+                expires_at=expires_at,
+                tags=tags or [],
+                priority=priority,
+                registered_at=now,
+            )
+
+            self._entries[registration_id] = entry
+            self._agent_id_to_reg_id[agent_id] = registration_id
+            self._add_to_indices(registration_id, agent_card)
+
+            return RegistrationResponse.success_response(
+                request_id, registration_id, expires_at.isoformat()
+            )
+
+    def deregister(self, registration_id: str, agent_id: str) -> DeregistrationResponse:
+        """
+        Remove an agent from the registry.
+
+        Args:
+            registration_id: The registration ID
+            agent_id: The agent ID for verification
+
+        Returns:
+            DeregistrationResponse with success status
+        """
+        request_id = str(uuid.uuid4())
+
+        with self._lock:
+            if registration_id not in self._entries:
+                return DeregistrationResponse(
+                    request_id=request_id,
+                    success=False,
+                    message="Registration not found",
+                )
+
+            entry = self._entries[registration_id]
+            if entry.agent_card.identity.agent_id != agent_id:
+                return DeregistrationResponse(
+                    request_id=request_id,
+                    success=False,
+                    message="Agent ID does not match registration",
+                )
+
+            self._remove_from_indices(registration_id)
+            del self._entries[registration_id]
+            if agent_id in self._agent_id_to_reg_id:
+                del self._agent_id_to_reg_id[agent_id]
+
+            return DeregistrationResponse(
+                request_id=request_id,
+                success=True,
+                message="Agent deregistered successfully",
+            )
+
+    def update(
+        self,
+        registration_id: str,
+        agent_card: AgentCard,
+        extend_ttl: bool = False,
+        new_ttl_seconds: int | None = None,
+    ) -> RegistrationResponse:
+        """
+        Update an existing registration.
+
+        Args:
+            registration_id: The registration ID to update
+            agent_card: Updated agent card
+            extend_ttl: Whether to extend the TTL
+            new_ttl_seconds: New TTL if extending
+
+        Returns:
+            RegistrationResponse with success status
+        """
+        request_id = str(uuid.uuid4())
+
+        with self._lock:
+            if registration_id not in self._entries:
+                return RegistrationResponse.error_response(
+                    request_id, "NOT_FOUND", "Registration not found"
+                )
+
+            entry = self._entries[registration_id]
+
+            # Update indices
+            self._remove_from_indices(registration_id)
+            self._add_to_indices(registration_id, agent_card)
+
+            # Update entry
+            entry.agent_card = agent_card
+            if extend_ttl and new_ttl_seconds:
+                entry.expires_at = datetime.fromtimestamp(
+                    datetime.now(timezone.utc).timestamp() + new_ttl_seconds,
+                    tz=timezone.utc,
+                )
+
+            return RegistrationResponse.success_response(
+                request_id, registration_id, entry.expires_at.isoformat()
+            )
+
+    def discover(self, request: DiscoveryRequest) -> DiscoveryResponse:
+        """
+        Discover agents matching the given criteria.
+
+        Args:
+            request: Discovery request with capabilities and constraints
+
+        Returns:
+            DiscoveryResponse with matching agents sorted by score
+        """
+        start_time = time.time()
+
+        with self._lock:
+            # Clean up expired entries
+            self._cleanup_expired()
+
+            # Get candidate agents from capability index
+            candidates = self._get_candidates(request.required_capabilities)
+
+            # Score and filter candidates
+            matches: list[AgentMatch] = []
+            for reg_id in candidates:
+                entry = self._entries.get(reg_id)
+                if not entry:
+                    continue
+
+                # Check if expired
+                if entry.expires_at < datetime.now(timezone.utc):
+                    continue
+
+                # Calculate match
+                match = self._score_agent(entry.agent_card, request)
+                if match:
+                    matches.append(match)
+
+            # Sort by score descending
+            matches.sort(key=lambda m: m.match_score, reverse=True)
+
+            # Limit results
+            total_count = len(matches)
+            matches = matches[: request.max_results]
+
+            elapsed_ms = int((time.time() - start_time) * 1000)
+
+            return DiscoveryResponse(
+                request_id=request.request_id,
+                agents=matches,
+                total_count=total_count,
+                returned_count=len(matches),
+                discovery_time_ms=elapsed_ms,
+                source=DiscoverySource.REGISTRY,
+                cached=False,
+            )
+
+    def get_agent(self, agent_id: str) -> AgentCard | None:
+        """Get an agent card by agent ID."""
+        with self._lock:
+            reg_id = self._agent_id_to_reg_id.get(agent_id)
+            if not reg_id:
+                return None
+            entry = self._entries.get(reg_id)
+            if not entry:
+                return None
+            if entry.expires_at < datetime.now(timezone.utc):
+                return None
+            return entry.agent_card
+
+    def get_status(self) -> RegistryStatus:
+        """Get the current status of the registry."""
+        with self._lock:
+            now = datetime.now(timezone.utc)
+            uptime = int((now - self._start_time).total_seconds())
+            total_requests = self._cache_hits + self._cache_misses
+            cache_hit_rate = (
+                self._cache_hits / total_requests if total_requests > 0 else 0.0
+            )
+
+            return RegistryStatus(
+                healthy=True,
+                agent_count=len(self._entries),
+                capability_count=len(self._capability_index),
+                last_cleanup=self._last_cleanup.isoformat(),
+                uptime_seconds=uptime,
+                cache_hit_rate=cache_hit_rate,
+            )
+
+    def get_capability_stats(self, capability_id: str) -> CapabilityStats | None:
+        """Get statistics for a specific capability."""
+        with self._lock:
+            agent_ids = self._capability_index.get(capability_id)
+            if not agent_ids:
+                return None
+
+            protocols: set[ProtocolType] = set()
+            versions: list[str] = []
+
+            for reg_id in agent_ids:
+                entry = self._entries.get(reg_id)
+                if not entry:
+                    continue
+
+                for protocol in entry.agent_card.supported_protocols:
+                    protocols.add(protocol.protocol)
+
+                # Use agent card version since capabilities don't have version
+                for cap in entry.agent_card.capabilities:
+                    if cap.capability_id == capability_id:
+                        versions.append(entry.agent_card.identity.version)
+
+            # Calculate average version (simplified - just take the first)
+            avg_version = versions[0] if versions else "0.0.0"
+
+            return CapabilityStats(
+                capability_id=capability_id,
+                agent_count=len(agent_ids),
+                average_version=avg_version,
+                protocols=list(protocols),
+            )
+
+    def list_capabilities(self) -> list[str]:
+        """List all registered capabilities."""
+        with self._lock:
+            return list(self._capability_index.keys())
+
+    def list_agents(self) -> list[str]:
+        """List all registered agent IDs."""
+        with self._lock:
+            return list(self._agent_id_to_reg_id.keys())
+
+    def clear(self) -> None:
+        """Clear all registrations."""
+        with self._lock:
+            self._entries.clear()
+            self._agent_id_to_reg_id.clear()
+            self._capability_index.clear()
+            self._protocol_index.clear()
+            self._provider_index.clear()
+
+    # ============================================
+    # Private Methods
+    # ============================================
+
+    def _add_to_indices(self, registration_id: str, agent_card: AgentCard) -> None:
+        """Add an agent to all indices."""
+        # Capability index
+        for capability in agent_card.capabilities:
+            cap_id = capability.capability_id
+            if cap_id not in self._capability_index:
+                self._capability_index[cap_id] = set()
+            self._capability_index[cap_id].add(registration_id)
+
+        # Protocol index
+        for protocol in agent_card.supported_protocols:
+            if protocol.protocol not in self._protocol_index:
+                self._protocol_index[protocol.protocol] = set()
+            self._protocol_index[protocol.protocol].add(registration_id)
+
+        # Provider index
+        provider = agent_card.identity.provider
+        if provider:
+            if provider not in self._provider_index:
+                self._provider_index[provider] = set()
+            self._provider_index[provider].add(registration_id)
+
+    def _remove_from_indices(self, registration_id: str) -> None:
+        """Remove an agent from all indices."""
+        entry = self._entries.get(registration_id)
+        if not entry:
+            return
+
+        agent_card = entry.agent_card
+
+        # Capability index
+        for capability in agent_card.capabilities:
+            cap_id = capability.capability_id
+            if cap_id in self._capability_index:
+                self._capability_index[cap_id].discard(registration_id)
+                if not self._capability_index[cap_id]:
+                    del self._capability_index[cap_id]
+
+        # Protocol index
+        for protocol in agent_card.supported_protocols:
+            if protocol.protocol in self._protocol_index:
+                self._protocol_index[protocol.protocol].discard(registration_id)
+                if not self._protocol_index[protocol.protocol]:
+                    del self._protocol_index[protocol.protocol]
+
+        # Provider index
+        provider = agent_card.identity.provider
+        if provider and provider in self._provider_index:
+            self._provider_index[provider].discard(registration_id)
+            if not self._provider_index[provider]:
+                del self._provider_index[provider]
+
+    def _get_candidates(self, required_capabilities: list[str]) -> set[str]:
+        """Get candidate registration IDs from capability index."""
+        if not required_capabilities:
+            return set(self._entries.keys())
+
+        # Start with agents that have the first capability
+        first_cap = required_capabilities[0]
+        candidates = self._capability_index.get(first_cap, set()).copy()
+
+        # Intersect with agents that have remaining capabilities
+        for cap_id in required_capabilities[1:]:
+            cap_agents = self._capability_index.get(cap_id, set())
+            candidates &= cap_agents
+
+        return candidates
+
+    def _score_agent(
+        self, agent_card: AgentCard, request: DiscoveryRequest
+    ) -> AgentMatch | None:
+        """Score an agent against the discovery request."""
+        # Get agent capabilities
+        agent_cap_ids = {cap.capability_id for cap in agent_card.capabilities}
+
+        # Calculate capability coverage
+        required = set(request.required_capabilities)
+        matched = required & agent_cap_ids
+        missing = required - agent_cap_ids
+
+        if missing and not request.include_inactive:
+            # Missing required capabilities
+            return None
+
+        capability_coverage = len(matched) / len(required) if required else 1.0
+
+        # Calculate constraint satisfaction
+        constraint_score, notes = self._evaluate_constraints(
+            agent_card, request.constraints
+        )
+
+        # Check if required constraints are met
+        for constraint in request.constraints:
+            if constraint.required:
+                if not self._evaluate_single_constraint(agent_card, constraint):
+                    return None
+
+        # Calculate optional capability bonus
+        optional = set(request.optional_capabilities)
+        optional_matched = optional & agent_cap_ids
+        optional_bonus = (
+            len(optional_matched) / len(optional) * 0.1 if optional else 0.0
+        )
+
+        # Calculate overall score
+        match_score = (
+            capability_coverage * 0.6 + constraint_score * 0.3 + optional_bonus + 0.1
+        )
+        match_score = min(1.0, match_score)
+
+        return AgentMatch(
+            agent=agent_card,
+            match_score=match_score,
+            capability_coverage=capability_coverage,
+            constraint_satisfaction=constraint_score,
+            matched_capabilities=list(matched),
+            missing_capabilities=list(missing),
+            compatibility_notes=notes,
+        )
+
+    def _evaluate_constraints(
+        self, agent_card: AgentCard, constraints: list[DiscoveryConstraint]
+    ) -> tuple[float, list[str]]:
+        """Evaluate all constraints and return score and notes."""
+        if not constraints:
+            return 1.0, []
+
+        total_weight = sum(c.weight for c in constraints)
+        satisfied_weight = 0.0
+        notes: list[str] = []
+
+        for constraint in constraints:
+            if self._evaluate_single_constraint(agent_card, constraint):
+                satisfied_weight += constraint.weight
+            else:
+                notes.append(
+                    f"Constraint not met: {constraint.field} {constraint.operator.value} {constraint.value}"
+                )
+
+        score = satisfied_weight / total_weight if total_weight > 0 else 1.0
+        return score, notes
+
+    def _evaluate_single_constraint(
+        self, agent_card: AgentCard, constraint: DiscoveryConstraint
+    ) -> bool:
+        """Evaluate a single constraint against an agent card."""
+        # Get the field value
+        value = self._get_field_value(agent_card, constraint.field)
+        if value is None:
+            return False
+
+        target = constraint.value
+        op = constraint.operator
+
+        # String comparison
+        if isinstance(value, str):
+            if op == ConstraintOperator.EQUALS:
+                return value == target
+            elif op == ConstraintOperator.NOT_EQUALS:
+                return value != target
+            elif op == ConstraintOperator.CONTAINS:
+                return target in value
+            elif op == ConstraintOperator.REGEX:
+                return bool(re.match(target, value))
+
+        # List comparison
+        if isinstance(value, list):
+            if op == ConstraintOperator.IN:
+                return target in value
+            elif op == ConstraintOperator.NOT_IN:
+                return target not in value
+            elif op == ConstraintOperator.CONTAINS:
+                return any(target in str(v) for v in value)
+
+        # Numeric comparison
+        try:
+            num_value = float(str(value))
+            num_target = float(target)
+            if op == ConstraintOperator.GREATER_THAN:
+                return num_value > num_target
+            elif op == ConstraintOperator.LESS_THAN:
+                return num_value < num_target
+            elif op == ConstraintOperator.GREATER_OR_EQUAL:
+                return num_value >= num_target
+            elif op == ConstraintOperator.LESS_OR_EQUAL:
+                return num_value <= num_target
+        except (ValueError, TypeError):
+            pass
+
+        return False
+
+    def _get_field_value(self, agent_card: AgentCard, field_path: str) -> Any:
+        """Get a field value from agent card using dot notation."""
+        parts = field_path.split(".")
+        obj: Any = agent_card
+
+        for part in parts:
+            if hasattr(obj, part):
+                obj = getattr(obj, part)
+            elif isinstance(obj, dict) and part in obj:
+                obj = obj[part]
+            else:
+                return None
+
+        return obj
+
+    def _cleanup_expired(self) -> None:
+        """Remove expired registrations."""
+        now = datetime.now(timezone.utc)
+        expired = [
+            reg_id
+            for reg_id, entry in self._entries.items()
+            if entry.expires_at < now
+        ]
+
+        for reg_id in expired:
+            entry = self._entries[reg_id]
+            agent_id = entry.agent_card.identity.agent_id
+            self._remove_from_indices(reg_id)
+            del self._entries[reg_id]
+            if agent_id in self._agent_id_to_reg_id:
+                del self._agent_id_to_reg_id[agent_id]
+
+        self._last_cleanup = now

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -1,0 +1,1181 @@
+"""
+Tests for Capability Registry & Discovery Service
+
+Issue #55 - Phase 3: Agent-to-Agent Interface Negotiation
+"""
+
+import time
+
+import pytest
+
+from src.lui_simulator.agent_types import (
+    AgentIdentity,
+    AgentCapability,
+    CapabilityType,
+    SchemaDefinition,
+)
+from src.agent_negotiation.agent_card import (
+    AgentCard,
+    SupportedProtocol,
+    ProtocolType,
+    CardEndpoint,
+    EndpointType,
+)
+from src.agent_negotiation.capability_registry import (
+    ConstraintType,
+    ConstraintOperator,
+    DiscoveryConstraint,
+    DiscoverySource,
+    DiscoveryRequest,
+    AgentMatch,
+    DiscoveryResponse,
+    RegistrationRequest,
+    RegistrationError,
+    RegistrationResponse,
+    DeregistrationRequest,
+    RegistryStatus,
+    CapabilityStats,
+    CapabilityIndex,
+    CapabilityRegistry,
+)
+
+
+# ============================================
+# Fixtures
+# ============================================
+
+
+@pytest.fixture
+def sample_identity() -> AgentIdentity:
+    """Create a sample agent identity."""
+    return AgentIdentity(
+        agent_id="urn:agent:acme:assistant:1.0.0",
+        name="Acme Assistant",
+        version="1.0.0",
+        description="A helpful assistant agent",
+        provider="acme",
+    )
+
+
+@pytest.fixture
+def sample_capability() -> AgentCapability:
+    """Create a sample capability."""
+    return AgentCapability.create(
+        name="text-generation",
+        description="Generate text based on prompts",
+        capability_type=CapabilityType.ACTION,
+        input_schema=SchemaDefinition.string(description="Input text"),
+        output_schema=SchemaDefinition.string(description="Generated text"),
+    )
+
+
+@pytest.fixture
+def sample_protocol() -> SupportedProtocol:
+    """Create a sample protocol."""
+    return SupportedProtocol(
+        protocol=ProtocolType.A2A,
+        version="1.0.0",
+    )
+
+
+@pytest.fixture
+def sample_endpoint() -> CardEndpoint:
+    """Create a sample endpoint."""
+    return CardEndpoint(
+        endpoint_type=EndpointType.PRIMARY,
+        url="https://api.acme.com/agent",
+        protocol=ProtocolType.A2A,
+    )
+
+
+@pytest.fixture
+def sample_agent_card(
+    sample_identity: AgentIdentity,
+    sample_capability: AgentCapability,
+    sample_protocol: SupportedProtocol,
+    sample_endpoint: CardEndpoint,
+) -> AgentCard:
+    """Create a sample agent card."""
+    return AgentCard(
+        identity=sample_identity,
+        capabilities=[sample_capability],
+        supported_protocols=[sample_protocol],
+        endpoints=[sample_endpoint],
+    )
+
+
+@pytest.fixture
+def registry() -> CapabilityRegistry:
+    """Create a fresh registry."""
+    return CapabilityRegistry()
+
+
+def create_agent_card(
+    agent_id: str,
+    name: str,
+    provider: str,
+    capabilities: list[str],
+    protocols: list[ProtocolType] | None = None,
+) -> AgentCard:
+    """Helper to create agent cards with specific capabilities."""
+    identity = AgentIdentity(
+        agent_id=agent_id,
+        name=name,
+        version="1.0.0",
+        description=f"Agent {name}",
+        provider=provider,
+    )
+
+    caps = [
+        AgentCapability.create(
+            name=cap_id,
+            description=f"Description for {cap_id}",
+            capability_type=CapabilityType.ACTION,
+            input_schema=SchemaDefinition.string(),
+            output_schema=SchemaDefinition.string(),
+        )
+        for cap_id in capabilities
+    ]
+    # Override capability_id to match expected values
+    for cap, cap_id in zip(caps, capabilities):
+        object.__setattr__(cap, "capability_id", cap_id)
+
+    prots = [
+        SupportedProtocol(protocol=p, version="1.0.0")
+        for p in (protocols or [ProtocolType.A2A])
+    ]
+
+    endpoints = [
+        CardEndpoint(
+            endpoint_type=EndpointType.PRIMARY,
+            url=f"https://api.{provider}.com/{name.lower().replace(' ', '-')}",
+            protocol=prots[0].protocol if prots else ProtocolType.A2A,
+        )
+    ]
+
+    return AgentCard(
+        identity=identity,
+        capabilities=caps,
+        supported_protocols=prots,
+        endpoints=endpoints,
+    )
+
+
+# ============================================
+# Constraint Type Tests
+# ============================================
+
+
+class TestConstraintTypes:
+    """Tests for constraint types."""
+
+    def test_constraint_type_values(self):
+        """Test ConstraintType enum values."""
+        assert ConstraintType.CAPABILITY.value == "capability"
+        assert ConstraintType.PROTOCOL.value == "protocol"
+        assert ConstraintType.COMPLIANCE.value == "compliance"
+        assert ConstraintType.TRUST_LEVEL.value == "trust_level"
+        assert ConstraintType.REGION.value == "region"
+        assert ConstraintType.PROVIDER.value == "provider"
+
+    def test_constraint_operator_values(self):
+        """Test ConstraintOperator enum values."""
+        assert ConstraintOperator.EQUALS.value == "equals"
+        assert ConstraintOperator.NOT_EQUALS.value == "not_equals"
+        assert ConstraintOperator.CONTAINS.value == "contains"
+        assert ConstraintOperator.IN.value == "in"
+        assert ConstraintOperator.REGEX.value == "regex"
+
+    def test_discovery_constraint_creation(self):
+        """Test creating a discovery constraint."""
+        constraint = DiscoveryConstraint(
+            constraint_type=ConstraintType.PROVIDER,
+            field="identity.provider",
+            operator=ConstraintOperator.EQUALS,
+            value="acme",
+            weight=1.0,
+            required=True,
+        )
+
+        assert constraint.constraint_type == ConstraintType.PROVIDER
+        assert constraint.field == "identity.provider"
+        assert constraint.operator == ConstraintOperator.EQUALS
+        assert constraint.value == "acme"
+        assert constraint.weight == 1.0
+        assert constraint.required is True
+
+    def test_discovery_constraint_to_dict(self):
+        """Test constraint serialization."""
+        constraint = DiscoveryConstraint(
+            constraint_type=ConstraintType.PROTOCOL,
+            field="supported_protocols",
+            operator=ConstraintOperator.IN,
+            value="a2a",
+            weight=0.8,
+            required=False,
+        )
+
+        data = constraint.to_dict()
+        assert data["constraint_type"] == "protocol"
+        assert data["operator"] == "in"
+        assert data["weight"] == 0.8
+        assert data["required"] is False
+
+
+# ============================================
+# Discovery Types Tests
+# ============================================
+
+
+class TestDiscoveryTypes:
+    """Tests for discovery types."""
+
+    def test_discovery_source_values(self):
+        """Test DiscoverySource enum values."""
+        assert DiscoverySource.REGISTRY.value == "registry"
+        assert DiscoverySource.CACHE.value == "cache"
+        assert DiscoverySource.PEER_DISCOVERY.value == "peer_discovery"
+        assert DiscoverySource.LOCAL.value == "local"
+        assert DiscoverySource.WELL_KNOWN.value == "well_known"
+
+    def test_discovery_request_creation(self, sample_identity: AgentIdentity):
+        """Test creating a discovery request."""
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:text-generation", "cap:summarization"],
+            max_results=5,
+        )
+
+        assert request.requester == sample_identity
+        assert len(request.required_capabilities) == 2
+        assert request.max_results == 5
+        assert request.request_id is not None
+        assert request.requested_at is not None
+
+    def test_discovery_request_to_dict(self, sample_identity: AgentIdentity):
+        """Test discovery request serialization."""
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:text-generation"],
+            optional_capabilities=["cap:translation"],
+            max_results=10,
+            timeout_ms=5000,
+        )
+
+        data = request.to_dict()
+        assert "request_id" in data
+        assert data["required_capabilities"] == ["cap:text-generation"]
+        assert data["optional_capabilities"] == ["cap:translation"]
+        assert data["max_results"] == 10
+        assert data["timeout_ms"] == 5000
+
+    def test_agent_match_creation(self, sample_agent_card: AgentCard):
+        """Test creating an agent match."""
+        match = AgentMatch(
+            agent=sample_agent_card,
+            match_score=0.95,
+            capability_coverage=1.0,
+            constraint_satisfaction=0.9,
+            matched_capabilities=["cap:text-generation"],
+            compatibility_notes=["Full protocol support"],
+        )
+
+        assert match.match_score == 0.95
+        assert match.capability_coverage == 1.0
+        assert len(match.matched_capabilities) == 1
+
+    def test_agent_match_to_dict(self, sample_agent_card: AgentCard):
+        """Test agent match serialization."""
+        match = AgentMatch(
+            agent=sample_agent_card,
+            match_score=0.8,
+            capability_coverage=0.75,
+            constraint_satisfaction=0.85,
+            matched_capabilities=["cap:text-generation"],
+            missing_capabilities=["cap:summarization"],
+        )
+
+        data = match.to_dict()
+        assert data["match_score"] == 0.8
+        assert "agent" in data
+        assert data["missing_capabilities"] == ["cap:summarization"]
+
+    def test_discovery_response_creation(self, sample_agent_card: AgentCard):
+        """Test creating a discovery response."""
+        match = AgentMatch(
+            agent=sample_agent_card,
+            match_score=0.9,
+            capability_coverage=1.0,
+            constraint_satisfaction=1.0,
+            matched_capabilities=["cap:text-generation"],
+        )
+
+        response = DiscoveryResponse(
+            request_id="test-req-id",
+            agents=[match],
+            total_count=1,
+            returned_count=1,
+            discovery_time_ms=5,
+            source=DiscoverySource.REGISTRY,
+        )
+
+        assert len(response.agents) == 1
+        assert response.total_count == 1
+        assert response.source == DiscoverySource.REGISTRY
+
+
+# ============================================
+# Registration Types Tests
+# ============================================
+
+
+class TestRegistrationTypes:
+    """Tests for registration types."""
+
+    def test_registration_request_creation(self, sample_agent_card: AgentCard):
+        """Test creating a registration request."""
+        request = RegistrationRequest(
+            agent_card=sample_agent_card,
+            ttl_seconds=7200,
+            tags=["production", "us-west"],
+            priority=10,
+        )
+
+        assert request.ttl_seconds == 7200
+        assert "production" in request.tags
+        assert request.priority == 10
+
+    def test_registration_error_creation(self):
+        """Test creating a registration error."""
+        error = RegistrationError(
+            error_code="INVALID_AGENT_ID",
+            message="Agent ID is required",
+            field="identity.agent_id",
+        )
+
+        assert error.error_code == "INVALID_AGENT_ID"
+        assert error.field == "identity.agent_id"
+
+    def test_registration_response_success(self):
+        """Test creating a success response."""
+        response = RegistrationResponse.success_response(
+            request_id="req-123",
+            registration_id="reg-456",
+            expires_at="2025-12-31T23:59:59Z",
+        )
+
+        assert response.success is True
+        assert response.registration_id == "reg-456"
+        assert response.error is None
+
+    def test_registration_response_error(self):
+        """Test creating an error response."""
+        response = RegistrationResponse.error_response(
+            request_id="req-123",
+            error_code="DUPLICATE_AGENT",
+            message="Agent already registered",
+        )
+
+        assert response.success is False
+        assert response.registration_id is None
+        assert response.error is not None
+        assert response.error.error_code == "DUPLICATE_AGENT"
+
+    def test_deregistration_request_creation(self):
+        """Test creating a deregistration request."""
+        request = DeregistrationRequest(
+            registration_id="reg-123",
+            agent_id="urn:agent:acme:test:1.0.0",
+            reason="Shutdown",
+        )
+
+        assert request.registration_id == "reg-123"
+        assert request.reason == "Shutdown"
+
+
+# ============================================
+# Registry Status Tests
+# ============================================
+
+
+class TestRegistryStatus:
+    """Tests for registry status types."""
+
+    def test_registry_status_creation(self):
+        """Test creating registry status."""
+        status = RegistryStatus(
+            healthy=True,
+            agent_count=100,
+            capability_count=50,
+            last_cleanup="2025-12-30T12:00:00Z",
+            uptime_seconds=86400,
+            cache_hit_rate=0.85,
+        )
+
+        assert status.healthy is True
+        assert status.agent_count == 100
+        assert status.cache_hit_rate == 0.85
+
+    def test_capability_stats_creation(self):
+        """Test creating capability stats."""
+        stats = CapabilityStats(
+            capability_id="cap:text-generation",
+            agent_count=25,
+            average_version="1.2.0",
+            protocols=[ProtocolType.A2A, ProtocolType.MCP],
+        )
+
+        assert stats.agent_count == 25
+        assert len(stats.protocols) == 2
+
+    def test_capability_index_creation(self):
+        """Test creating capability index."""
+        index = CapabilityIndex(
+            capability_id="cap:summarization",
+            agent_ids=["agent-1", "agent-2", "agent-3"],
+            last_updated="2025-12-30T12:00:00Z",
+        )
+
+        assert len(index.agent_ids) == 3
+
+
+# ============================================
+# Capability Registry Tests
+# ============================================
+
+
+class TestCapabilityRegistry:
+    """Tests for the capability registry."""
+
+    def test_registry_creation(self, registry: CapabilityRegistry):
+        """Test creating a registry."""
+        status = registry.get_status()
+        assert status.healthy is True
+        assert status.agent_count == 0
+        assert status.capability_count == 0
+
+    def test_register_agent(
+        self, registry: CapabilityRegistry, sample_agent_card: AgentCard
+    ):
+        """Test registering an agent."""
+        response = registry.register(sample_agent_card, ttl_seconds=3600)
+
+        assert response.success is True
+        assert response.registration_id is not None
+        assert response.expires_at is not None
+
+        status = registry.get_status()
+        assert status.agent_count == 1
+
+    def test_register_duplicate_updates(
+        self, registry: CapabilityRegistry, sample_agent_card: AgentCard
+    ):
+        """Test that duplicate registration updates existing entry."""
+        response1 = registry.register(sample_agent_card, ttl_seconds=3600)
+        response2 = registry.register(sample_agent_card, ttl_seconds=7200)
+
+        assert response1.success is True
+        assert response2.success is True
+        # Different registration IDs
+        assert response1.registration_id != response2.registration_id
+
+        status = registry.get_status()
+        # Only one agent
+        assert status.agent_count == 1
+
+    def test_register_invalid_agent(self, registry: CapabilityRegistry):
+        """Test registering an agent with invalid ID."""
+        identity = AgentIdentity(
+            agent_id="",  # Invalid empty ID
+            name="Invalid Agent",
+            version="1.0.0",
+            description="Invalid",
+        )
+        card = AgentCard(
+            identity=identity,
+            capabilities=[],
+            supported_protocols=[
+                SupportedProtocol(protocol=ProtocolType.A2A, version="1.0.0")
+            ],
+            endpoints=[
+                CardEndpoint(
+                    endpoint_type=EndpointType.PRIMARY,
+                    url="https://example.com",
+                    protocol=ProtocolType.A2A,
+                )
+            ],
+        )
+
+        response = registry.register(card)
+        assert response.success is False
+        assert response.error is not None
+        assert response.error.error_code == "INVALID_AGENT_ID"
+
+    def test_deregister_agent(
+        self, registry: CapabilityRegistry, sample_agent_card: AgentCard
+    ):
+        """Test deregistering an agent."""
+        reg_response = registry.register(sample_agent_card)
+        assert reg_response.success is True
+
+        dereg_response = registry.deregister(
+            registration_id=reg_response.registration_id,
+            agent_id=sample_agent_card.identity.agent_id,
+        )
+        assert dereg_response.success is True
+
+        status = registry.get_status()
+        assert status.agent_count == 0
+
+    def test_deregister_not_found(self, registry: CapabilityRegistry):
+        """Test deregistering a non-existent agent."""
+        response = registry.deregister(
+            registration_id="nonexistent",
+            agent_id="urn:agent:test:unknown:1.0.0",
+        )
+        assert response.success is False
+        assert "not found" in response.message.lower()
+
+    def test_deregister_wrong_agent_id(
+        self, registry: CapabilityRegistry, sample_agent_card: AgentCard
+    ):
+        """Test deregistering with wrong agent ID."""
+        reg_response = registry.register(sample_agent_card)
+
+        dereg_response = registry.deregister(
+            registration_id=reg_response.registration_id,
+            agent_id="urn:agent:wrong:id:1.0.0",
+        )
+        assert dereg_response.success is False
+        assert "does not match" in dereg_response.message.lower()
+
+    def test_update_registration(
+        self, registry: CapabilityRegistry, sample_agent_card: AgentCard
+    ):
+        """Test updating a registration."""
+        reg_response = registry.register(sample_agent_card, ttl_seconds=3600)
+
+        # Create updated card
+        updated_identity = AgentIdentity(
+            agent_id=sample_agent_card.identity.agent_id,
+            name="Updated Name",
+            version="1.1.0",
+            description="Updated description",
+            provider=sample_agent_card.identity.provider,
+        )
+        updated_card = AgentCard(
+            identity=updated_identity,
+            capabilities=sample_agent_card.capabilities,
+            supported_protocols=sample_agent_card.supported_protocols,
+            endpoints=sample_agent_card.endpoints,
+        )
+
+        update_response = registry.update(
+            registration_id=reg_response.registration_id,
+            agent_card=updated_card,
+            extend_ttl=True,
+            new_ttl_seconds=7200,
+        )
+
+        assert update_response.success is True
+
+        # Verify update
+        agent = registry.get_agent(sample_agent_card.identity.agent_id)
+        assert agent is not None
+        assert agent.identity.name == "Updated Name"
+        assert agent.identity.version == "1.1.0"
+
+    def test_get_agent(
+        self, registry: CapabilityRegistry, sample_agent_card: AgentCard
+    ):
+        """Test getting an agent by ID."""
+        registry.register(sample_agent_card)
+
+        agent = registry.get_agent(sample_agent_card.identity.agent_id)
+        assert agent is not None
+        assert agent.identity.name == sample_agent_card.identity.name
+
+    def test_get_agent_not_found(self, registry: CapabilityRegistry):
+        """Test getting a non-existent agent."""
+        agent = registry.get_agent("urn:agent:unknown:test:1.0.0")
+        assert agent is None
+
+    def test_list_capabilities(self, registry: CapabilityRegistry):
+        """Test listing registered capabilities."""
+        card1 = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0",
+            "Agent 1",
+            "acme",
+            ["cap:text-gen", "cap:summarize"],
+        )
+        card2 = create_agent_card(
+            "urn:agent:acme:agent2:1.0.0",
+            "Agent 2",
+            "acme",
+            ["cap:translate", "cap:summarize"],
+        )
+
+        registry.register(card1)
+        registry.register(card2)
+
+        capabilities = registry.list_capabilities()
+        assert "cap:text-gen" in capabilities
+        assert "cap:summarize" in capabilities
+        assert "cap:translate" in capabilities
+
+    def test_list_agents(self, registry: CapabilityRegistry):
+        """Test listing registered agents."""
+        card1 = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0", "Agent 1", "acme", ["cap:test"]
+        )
+        card2 = create_agent_card(
+            "urn:agent:acme:agent2:1.0.0", "Agent 2", "acme", ["cap:test"]
+        )
+
+        registry.register(card1)
+        registry.register(card2)
+
+        agents = registry.list_agents()
+        assert len(agents) == 2
+        assert "urn:agent:acme:agent1:1.0.0" in agents
+        assert "urn:agent:acme:agent2:1.0.0" in agents
+
+    def test_clear_registry(
+        self, registry: CapabilityRegistry, sample_agent_card: AgentCard
+    ):
+        """Test clearing the registry."""
+        registry.register(sample_agent_card)
+        assert registry.get_status().agent_count == 1
+
+        registry.clear()
+        assert registry.get_status().agent_count == 0
+        assert registry.get_status().capability_count == 0
+
+
+# ============================================
+# Discovery Tests
+# ============================================
+
+
+class TestDiscovery:
+    """Tests for agent discovery."""
+
+    def test_discover_by_capability(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test discovering agents by capability."""
+        # Register agents with different capabilities
+        card1 = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0",
+            "Agent 1",
+            "acme",
+            ["cap:text-gen", "cap:summarize"],
+        )
+        card2 = create_agent_card(
+            "urn:agent:acme:agent2:1.0.0",
+            "Agent 2",
+            "acme",
+            ["cap:translate"],
+        )
+        card3 = create_agent_card(
+            "urn:agent:acme:agent3:1.0.0",
+            "Agent 3",
+            "acme",
+            ["cap:text-gen", "cap:translate"],
+        )
+
+        registry.register(card1)
+        registry.register(card2)
+        registry.register(card3)
+
+        # Discover agents with text-gen capability
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:text-gen"],
+            max_results=10,
+        )
+
+        response = registry.discover(request)
+
+        assert response.total_count == 2
+        agent_ids = [m.agent.identity.agent_id for m in response.agents]
+        assert "urn:agent:acme:agent1:1.0.0" in agent_ids
+        assert "urn:agent:acme:agent3:1.0.0" in agent_ids
+        assert "urn:agent:acme:agent2:1.0.0" not in agent_ids
+
+    def test_discover_multiple_capabilities(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test discovering agents with multiple required capabilities."""
+        card1 = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0",
+            "Agent 1",
+            "acme",
+            ["cap:text-gen", "cap:summarize"],
+        )
+        card2 = create_agent_card(
+            "urn:agent:acme:agent2:1.0.0",
+            "Agent 2",
+            "acme",
+            ["cap:text-gen"],
+        )
+
+        registry.register(card1)
+        registry.register(card2)
+
+        # Require both capabilities
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:text-gen", "cap:summarize"],
+            max_results=10,
+        )
+
+        response = registry.discover(request)
+
+        assert response.total_count == 1
+        assert response.agents[0].agent.identity.agent_id == "urn:agent:acme:agent1:1.0.0"
+        assert response.agents[0].capability_coverage == 1.0
+
+    def test_discover_with_optional_capabilities(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test discovering with optional capabilities."""
+        card1 = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0",
+            "Agent 1",
+            "acme",
+            ["cap:text-gen", "cap:translate"],
+        )
+        card2 = create_agent_card(
+            "urn:agent:acme:agent2:1.0.0",
+            "Agent 2",
+            "acme",
+            ["cap:text-gen"],
+        )
+
+        registry.register(card1)
+        registry.register(card2)
+
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:text-gen"],
+            optional_capabilities=["cap:translate"],
+            max_results=10,
+        )
+
+        response = registry.discover(request)
+
+        assert response.total_count == 2
+        # Agent 1 should score higher due to optional capability
+        assert response.agents[0].agent.identity.agent_id == "urn:agent:acme:agent1:1.0.0"
+        assert response.agents[0].match_score > response.agents[1].match_score
+
+    def test_discover_with_constraints(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test discovering with constraints."""
+        card1 = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0",
+            "Agent 1",
+            "acme",
+            ["cap:text-gen"],
+        )
+        card2 = create_agent_card(
+            "urn:agent:other:agent2:1.0.0",
+            "Agent 2",
+            "other",
+            ["cap:text-gen"],
+        )
+
+        registry.register(card1)
+        registry.register(card2)
+
+        # Only agents from "acme" provider
+        constraint = DiscoveryConstraint(
+            constraint_type=ConstraintType.PROVIDER,
+            field="identity.provider",
+            operator=ConstraintOperator.EQUALS,
+            value="acme",
+            required=True,
+        )
+
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:text-gen"],
+            constraints=[constraint],
+            max_results=10,
+        )
+
+        response = registry.discover(request)
+
+        assert response.total_count == 1
+        assert response.agents[0].agent.identity.provider == "acme"
+
+    def test_discover_max_results(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test max_results limit."""
+        # Register 10 agents
+        for i in range(10):
+            card = create_agent_card(
+                f"urn:agent:acme:agent{i}:1.0.0",
+                f"Agent {i}",
+                "acme",
+                ["cap:text-gen"],
+            )
+            registry.register(card)
+
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:text-gen"],
+            max_results=3,
+        )
+
+        response = registry.discover(request)
+
+        assert response.total_count == 10
+        assert response.returned_count == 3
+        assert len(response.agents) == 3
+
+    def test_discover_empty_registry(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test discovery on empty registry."""
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:text-gen"],
+            max_results=10,
+        )
+
+        response = registry.discover(request)
+
+        assert response.total_count == 0
+        assert len(response.agents) == 0
+
+    def test_discover_no_matching_capabilities(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test discovery when no agents match."""
+        card = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0",
+            "Agent 1",
+            "acme",
+            ["cap:translate"],
+        )
+        registry.register(card)
+
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:text-gen"],
+            max_results=10,
+        )
+
+        response = registry.discover(request)
+
+        assert response.total_count == 0
+
+    def test_discover_scores_sorted(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test that results are sorted by score descending."""
+        card1 = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0",
+            "Agent 1",
+            "acme",
+            ["cap:text-gen"],
+        )
+        card2 = create_agent_card(
+            "urn:agent:acme:agent2:1.0.0",
+            "Agent 2",
+            "acme",
+            ["cap:text-gen", "cap:summarize", "cap:translate"],
+        )
+
+        registry.register(card1)
+        registry.register(card2)
+
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:text-gen"],
+            optional_capabilities=["cap:summarize", "cap:translate"],
+            max_results=10,
+        )
+
+        response = registry.discover(request)
+
+        scores = [m.match_score for m in response.agents]
+        assert scores == sorted(scores, reverse=True)
+
+
+# ============================================
+# Performance Tests
+# ============================================
+
+
+class TestPerformance:
+    """Performance tests for the registry."""
+
+    def test_register_1000_agents(self, registry: CapabilityRegistry):
+        """Test registering 1000 agents."""
+        start = time.time()
+
+        for i in range(1000):
+            card = create_agent_card(
+                f"urn:agent:acme:agent{i}:1.0.0",
+                f"Agent {i}",
+                "acme",
+                [f"cap:type{i % 10}", f"cap:common{i % 5}"],
+            )
+            registry.register(card)
+
+        elapsed = (time.time() - start) * 1000
+
+        assert registry.get_status().agent_count == 1000
+        # Should complete in reasonable time
+        assert elapsed < 5000  # 5 seconds
+
+    def test_discover_in_1000_agents(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test discovery performance with 1000 agents."""
+        # Register 1000 agents
+        for i in range(1000):
+            card = create_agent_card(
+                f"urn:agent:acme:agent{i}:1.0.0",
+                f"Agent {i}",
+                "acme",
+                [f"cap:type{i % 10}", "cap:common"],
+            )
+            registry.register(card)
+
+        # Discover agents with common capability
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:common"],
+            max_results=100,
+        )
+
+        response = registry.discover(request)
+
+        # Should find all 1000 agents (with cap:common)
+        assert response.total_count == 1000
+        # Discovery should be under 100ms
+        assert response.discovery_time_ms < 100
+
+
+# ============================================
+# TTL Expiration Tests
+# ============================================
+
+
+class TestTTLExpiration:
+    """Tests for TTL-based expiration."""
+
+    def test_expired_agent_not_discoverable(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test that expired agents are not returned in discovery."""
+        card = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0",
+            "Agent 1",
+            "acme",
+            ["cap:text-gen"],
+        )
+
+        # Register with very short TTL
+        registry.register(card, ttl_seconds=1)
+
+        # Wait for expiration
+        time.sleep(1.1)
+
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:text-gen"],
+            max_results=10,
+        )
+
+        response = registry.discover(request)
+        assert response.total_count == 0
+
+    def test_expired_agent_not_retrievable(self, registry: CapabilityRegistry):
+        """Test that expired agents are not returned by get_agent."""
+        card = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0",
+            "Agent 1",
+            "acme",
+            ["cap:text-gen"],
+        )
+
+        registry.register(card, ttl_seconds=1)
+
+        # Agent should be retrievable immediately
+        agent = registry.get_agent("urn:agent:acme:agent1:1.0.0")
+        assert agent is not None
+
+        # Wait for expiration
+        time.sleep(1.1)
+
+        # Agent should no longer be retrievable
+        agent = registry.get_agent("urn:agent:acme:agent1:1.0.0")
+        assert agent is None
+
+
+# ============================================
+# Capability Stats Tests
+# ============================================
+
+
+class TestCapabilityStats:
+    """Tests for capability statistics."""
+
+    def test_get_capability_stats(self, registry: CapabilityRegistry):
+        """Test getting capability statistics."""
+        card1 = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0",
+            "Agent 1",
+            "acme",
+            ["cap:text-gen"],
+            [ProtocolType.A2A],
+        )
+        card2 = create_agent_card(
+            "urn:agent:acme:agent2:1.0.0",
+            "Agent 2",
+            "acme",
+            ["cap:text-gen"],
+            [ProtocolType.MCP],
+        )
+
+        registry.register(card1)
+        registry.register(card2)
+
+        stats = registry.get_capability_stats("cap:text-gen")
+        assert stats is not None
+        assert stats.agent_count == 2
+        assert len(stats.protocols) == 2
+
+    def test_get_capability_stats_not_found(self, registry: CapabilityRegistry):
+        """Test getting stats for non-existent capability."""
+        stats = registry.get_capability_stats("cap:nonexistent")
+        assert stats is None
+
+
+# ============================================
+# Edge Cases
+# ============================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases."""
+
+    def test_empty_capabilities_discovery(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test discovery with empty required capabilities."""
+        card = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0",
+            "Agent 1",
+            "acme",
+            ["cap:text-gen"],
+        )
+        registry.register(card)
+
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=[],
+            max_results=10,
+        )
+
+        response = registry.discover(request)
+        # Should return all agents
+        assert response.total_count == 1
+
+    def test_constraint_not_equals(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test NOT_EQUALS constraint operator."""
+        card1 = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0", "Agent 1", "acme", ["cap:test"]
+        )
+        card2 = create_agent_card(
+            "urn:agent:other:agent2:1.0.0", "Agent 2", "other", ["cap:test"]
+        )
+
+        registry.register(card1)
+        registry.register(card2)
+
+        constraint = DiscoveryConstraint(
+            constraint_type=ConstraintType.PROVIDER,
+            field="identity.provider",
+            operator=ConstraintOperator.NOT_EQUALS,
+            value="acme",
+            required=True,
+        )
+
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:test"],
+            constraints=[constraint],
+            max_results=10,
+        )
+
+        response = registry.discover(request)
+
+        assert response.total_count == 1
+        assert response.agents[0].agent.identity.provider == "other"
+
+    def test_constraint_contains(
+        self, registry: CapabilityRegistry, sample_identity: AgentIdentity
+    ):
+        """Test CONTAINS constraint operator."""
+        card1 = create_agent_card(
+            "urn:agent:acme:agent1:1.0.0",
+            "Agent Alpha",
+            "acme",
+            ["cap:test"],
+        )
+        card2 = create_agent_card(
+            "urn:agent:acme:agent2:1.0.0",
+            "Agent Beta",
+            "acme",
+            ["cap:test"],
+        )
+
+        registry.register(card1)
+        registry.register(card2)
+
+        constraint = DiscoveryConstraint(
+            constraint_type=ConstraintType.PROVIDER,
+            field="identity.name",
+            operator=ConstraintOperator.CONTAINS,
+            value="Alpha",
+            required=True,
+        )
+
+        request = DiscoveryRequest(
+            requester=sample_identity,
+            required_capabilities=["cap:test"],
+            constraints=[constraint],
+            max_results=10,
+        )
+
+        response = registry.discover(request)
+
+        assert response.total_count == 1
+        assert "Alpha" in response.agents[0].agent.identity.name
+
+    def test_serialization_round_trip(self, sample_agent_card: AgentCard):
+        """Test that types serialize and deserialize correctly."""
+        match = AgentMatch(
+            agent=sample_agent_card,
+            match_score=0.95,
+            capability_coverage=1.0,
+            constraint_satisfaction=0.9,
+            matched_capabilities=["cap:text-generation"],
+        )
+
+        data = match.to_dict()
+
+        # Verify essential fields preserved
+        assert data["match_score"] == 0.95
+        assert data["capability_coverage"] == 1.0
+        assert "agent" in data


### PR DESCRIPTION
## Summary
- Implements Task 3.3: Capability Registry & Discovery Service from Phase 3
- Adds in-memory capability registry with inverted indexing for fast agent discovery
- Supports constraint-based filtering with weighted scoring

## Changes

### BAML Types (`baml_src/capability_discovery.baml`)
- **Constraint Types**: `ConstraintType` (CAPABILITY, PROTOCOL, COMPLIANCE, TRUST_LEVEL, REGION, PROVIDER, VERSION, PERFORMANCE)
- **Operators**: `ConstraintOperator` (EQUALS, NOT_EQUALS, CONTAINS, IN, NOT_IN, REGEX, comparisons)
- **Discovery**: `DiscoveryRequest` with required/optional capabilities, `AgentMatch` with scoring, `DiscoveryResponse`
- **Registry Operations**: Registration, update, and deregistration request/response types
- **Status**: `RegistryStatus`, `CapabilityStats`, `CapabilityIndex`

### Python Implementation (`src/agent_negotiation/capability_registry.py`)
- **CapabilityRegistry** class with thread-safe operations
- **Inverted Index**: O(1) lookup by capability ID
- **TTL Management**: Automatic expiration of stale registrations
- **Discovery Scoring**:
  - 60% weight for capability coverage
  - 30% weight for constraint satisfaction
  - 10% bonus for optional capabilities
- **Constraint Evaluation**: Field path extraction, multiple operators

### Performance
- Registration of 1000 agents: <5 seconds
- Discovery in 1000 agents: <100ms (requirement met)

### Tests (`tests/test_capability_registry.py`)
- 49 comprehensive tests
- Constraint type and operator tests
- Discovery with single/multiple/optional capabilities
- Constraint filtering tests
- Performance benchmarks
- TTL expiration tests

## Test Plan
- [x] All 49 new tests pass
- [x] Full test suite (1317 tests) passes
- [x] Ruff linting passes
- [x] Performance requirement met (<100ms for 1000 agents)

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)