### PR TITLE
feat(negotiation): Add negotiation state machine for agent-to-agent interface negotiation

### DIFF
--- a/baml_src/negotiation_protocol.baml
+++ b/baml_src/negotiation_protocol.baml
@@ -1,0 +1,321 @@
+// Negotiation Protocol Types
+// BAML types for managing agent-to-agent negotiation sessions
+// Issue #57 - Phase 3: Agent-to-Agent Interface Negotiation (Task 3.5)
+
+// Dependencies:
+// - AgentIdentity from agent_identity.baml
+// - CapabilityRequirement from agent_capability.baml
+
+// ============================================
+// Negotiation Status
+// ============================================
+
+/// Status of a negotiation session
+enum NegotiationStatus {
+  INITIATED @description("Session created, no proposal yet")
+  PROPOSAL_SENT @description("Initial proposal has been sent")
+  COUNTER_OFFERED @description("A counter-proposal has been made")
+  ACCEPTED @description("Negotiation concluded with agreement")
+  REJECTED @description("Negotiation concluded without agreement")
+  EXPIRED @description("Negotiation timed out")
+  CANCELLED @description("Negotiation was cancelled by a party")
+  ADAPTED @description("Negotiation resulted in capability adaptation")
+}
+
+/// Actions that can be taken in a negotiation
+enum NegotiationAction {
+  PROPOSE @description("Submit an initial proposal")
+  COUNTER @description("Submit a counter-proposal")
+  ACCEPT @description("Accept the current proposal")
+  REJECT @description("Reject the current proposal")
+  WITHDRAW @description("Withdraw from negotiation")
+  TIMEOUT @description("System-generated timeout action")
+}
+
+// ============================================
+// Negotiation Proposal
+// ============================================
+
+/// A proposal in a negotiation session
+class NegotiationProposal {
+  proposal_id string @description("Unique identifier for this proposal")
+  capability_requirements CapabilityNegotiationItem[] @description("Capabilities being negotiated")
+  terms NegotiationTerms @description("Terms of the proposal")
+  constraints ProposalConstraint[]? @description("Additional constraints on the proposal")
+  valid_until string @description("ISO 8601 expiry timestamp for this proposal")
+}
+
+/// An item representing a capability in negotiation
+class CapabilityNegotiationItem {
+  capability_id string @description("ID of the capability being negotiated")
+  capability_name string @description("Human-readable name")
+  requested_level string? @description("Requested capability level (e.g., 'full', 'limited')")
+  parameters NegotiationParameter[]? @description("Parameters being negotiated")
+  required bool @description("Whether this capability is required or optional")
+}
+
+/// A parameter being negotiated
+class NegotiationParameter {
+  name string @description("Parameter name")
+  requested_value string @description("Requested value")
+  acceptable_alternatives string[]? @description("Alternative acceptable values")
+  min_value string? @description("Minimum acceptable value for numeric params")
+  max_value string? @description("Maximum acceptable value for numeric params")
+}
+
+/// Terms of a negotiation proposal
+class NegotiationTerms {
+  duration_hours int? @description("Proposed agreement duration in hours")
+  rate_limit_per_minute int? @description("Proposed rate limit")
+  priority_level int? @description("Requested priority level (1-10)")
+  billing_model string? @description("Billing model (free, per_call, subscription)")
+  sla_requirements SLARequirement[]? @description("Service level requirements")
+}
+
+/// Service level agreement requirement
+class SLARequirement {
+  metric string @description("Metric name (e.g., 'response_time_ms', 'availability')")
+  target_value float @description("Target value for the metric")
+  measurement_window_hours int @description("Window for measuring the metric")
+}
+
+/// Additional constraint on a proposal
+class ProposalConstraint {
+  constraint_type ConstraintType @description("Type of constraint")
+  field string @description("Field the constraint applies to")
+  operator ConstraintOperator @description("Comparison operator")
+  value string @description("Constraint value")
+}
+
+/// Types of constraints
+enum ConstraintType {
+  REQUIRED @description("Must be satisfied")
+  PREFERRED @description("Preferred but not required")
+  PROHIBITED @description("Must not be present")
+}
+
+/// Comparison operators for constraints
+enum ConstraintOperator {
+  EQUALS @description("Exact match")
+  NOT_EQUALS @description("Must not match")
+  GREATER_THAN @description("Greater than value")
+  LESS_THAN @description("Less than value")
+  CONTAINS @description("Contains value")
+  IN @description("Value in list")
+}
+
+// ============================================
+// Negotiation Turn
+// ============================================
+
+/// A single turn in a negotiation
+class NegotiationTurn {
+  turn_number int @description("Sequential turn number (1-indexed)")
+  actor string @description("Agent ID of the actor taking this action")
+  action NegotiationAction @description("Action taken")
+  proposal NegotiationProposal? @description("Proposal if action is PROPOSE or COUNTER")
+  timestamp string @description("ISO 8601 timestamp of this turn")
+  rationale string? @description("Optional explanation for the action")
+  metadata TurnMetadata? @description("Additional metadata for this turn")
+}
+
+/// Metadata for a negotiation turn
+class TurnMetadata {
+  response_time_ms int? @description("Time to respond in milliseconds")
+  automated bool @description("Whether this was an automated response")
+  confidence float? @description("Confidence in the action (0.0-1.0)")
+  alternatives_considered int? @description("Number of alternatives considered")
+}
+
+// ============================================
+// Negotiation Session
+// ============================================
+
+/// A complete negotiation session between two agents
+class NegotiationSession {
+  session_id string @description("Unique identifier for this session")
+  initiator AgentIdentity @description("Agent that initiated the negotiation")
+  responder AgentIdentity @description("Agent responding to the negotiation")
+  status NegotiationStatus @description("Current status of the negotiation")
+  created_at string @description("ISO 8601 timestamp of session creation")
+  updated_at string @description("ISO 8601 timestamp of last update")
+  expires_at string @description("ISO 8601 timestamp when session expires")
+  history NegotiationTurn[] @description("Ordered list of turns in this session")
+  current_proposal NegotiationProposal? @description("The current active proposal")
+  result NegotiationResult? @description("Result if negotiation is complete")
+  context NegotiationContext? @description("Additional context for the negotiation")
+}
+
+/// Result of a completed negotiation
+class NegotiationResult {
+  outcome NegotiationOutcome @description("Final outcome")
+  agreed_proposal NegotiationProposal? @description("Agreed proposal if successful")
+  agreement_id string? @description("ID of resulting agreement/contract")
+  effective_from string? @description("When the agreement takes effect")
+  effective_until string? @description("When the agreement expires")
+  rejection_reasons string[]? @description("Reasons for rejection if applicable")
+}
+
+/// Possible negotiation outcomes
+enum NegotiationOutcome {
+  AGREEMENT @description("Parties reached an agreement")
+  NO_AGREEMENT @description("Parties could not reach agreement")
+  TIMEOUT @description("Negotiation expired without resolution")
+  CANCELLED @description("Negotiation was cancelled")
+  PARTIAL_AGREEMENT @description("Partial agreement on some capabilities")
+}
+
+/// Context for a negotiation session
+class NegotiationContext {
+  purpose string @description("Purpose of the negotiation")
+  urgency UrgencyLevel @description("Urgency level of the request")
+  previous_session_id string? @description("ID of related previous session")
+  tags string[]? @description("Tags for categorization")
+  custom_data string? @description("Custom JSON data")
+}
+
+/// Urgency level for a negotiation
+enum UrgencyLevel {
+  LOW @description("No time pressure")
+  NORMAL @description("Standard priority")
+  HIGH @description("Needs quick resolution")
+  CRITICAL @description("Urgent business need")
+}
+
+// ============================================
+// State Transition Validation
+// ============================================
+
+/// Request to transition negotiation state
+class StateTransitionRequest {
+  session_id string @description("Session to transition")
+  requested_status NegotiationStatus @description("Target status")
+  actor string @description("Agent requesting the transition")
+  action NegotiationAction @description("Action triggering the transition")
+  proposal NegotiationProposal? @description("Proposal if applicable")
+  rationale string? @description("Reason for the transition")
+}
+
+/// Result of a state transition attempt
+class StateTransitionResult {
+  success bool @description("Whether the transition was allowed")
+  previous_status NegotiationStatus @description("Status before transition")
+  new_status NegotiationStatus @description("Status after transition (or unchanged)")
+  turn_number int @description("Turn number if transition succeeded")
+  error StateTransitionError? @description("Error if transition failed")
+  warnings string[]? @description("Non-fatal warnings about the transition")
+}
+
+/// Error details for failed state transition
+class StateTransitionError {
+  error_code string @description("Machine-readable error code")
+  message string @description("Human-readable error message")
+  allowed_transitions NegotiationStatus[] @description("Valid target statuses from current state")
+  suggestion string? @description("Suggested action to resolve")
+}
+
+// ============================================
+// Negotiation AI Functions
+// ============================================
+
+/// Evaluate a proposal and suggest a response
+function EvaluateProposal(
+  session NegotiationSession,
+  our_identity AgentIdentity,
+  our_capabilities string[],
+  our_constraints ProposalConstraint[]?
+) -> ProposalEvaluation {
+  client CustomSonnet4
+  prompt #"
+    Evaluate the current proposal in this negotiation session and recommend a response.
+
+    Session:
+    {{ session }}
+
+    Our identity: {{ our_identity }}
+    Our capabilities: {{ our_capabilities }}
+    Our constraints: {{ our_constraints }}
+
+    Analyze the proposal and recommend whether to accept, counter, or reject.
+    If countering, suggest specific modifications to the proposal.
+
+    {{ ctx.output_format }}
+  "#
+}
+
+/// Result of proposal evaluation
+class ProposalEvaluation {
+  recommended_action NegotiationAction @description("Recommended action")
+  confidence float @description("Confidence in recommendation (0.0-1.0)")
+  reasoning string @description("Explanation for the recommendation")
+  suggested_counter NegotiationProposal? @description("Suggested counter-proposal if applicable")
+  risk_assessment RiskAssessment @description("Risk assessment of the proposal")
+  compatibility_score float @description("How well the proposal matches our capabilities (0.0-1.0)")
+}
+
+/// Risk assessment for a proposal
+class RiskAssessment {
+  overall_risk RiskLevel @description("Overall risk level")
+  factors RiskFactor[] @description("Individual risk factors")
+  mitigations string[]? @description("Suggested risk mitigations")
+}
+
+/// Risk level for negotiation
+enum RiskLevel {
+  LOW @description("Minimal risk")
+  MODERATE @description("Some concerns but manageable")
+  HIGH @description("Significant concerns")
+  CRITICAL @description("Unacceptable risk")
+}
+
+/// Individual risk factor
+class RiskFactor {
+  category string @description("Risk category")
+  description string @description("Description of the risk")
+  severity RiskLevel @description("Severity of this factor")
+  likelihood float @description("Likelihood of occurrence (0.0-1.0)")
+}
+
+/// Generate an optimal counter-proposal
+function GenerateCounterProposal(
+  session NegotiationSession,
+  our_identity AgentIdentity,
+  our_capabilities string[],
+  negotiation_strategy NegotiationStrategy
+) -> NegotiationProposal {
+  client CustomSonnet4
+  prompt #"
+    Generate an optimal counter-proposal for this negotiation.
+
+    Session: {{ session }}
+    Our identity: {{ our_identity }}
+    Our capabilities: {{ our_capabilities }}
+    Strategy: {{ negotiation_strategy }}
+
+    Create a counter-proposal that:
+    1. Moves toward agreement while protecting our interests
+    2. Addresses the other party's key concerns
+    3. Follows the specified negotiation strategy
+
+    {{ ctx.output_format }}
+  "#
+}
+
+/// Negotiation strategy configuration
+class NegotiationStrategy {
+  approach StrategyApproach @description("Overall approach")
+  priority_capabilities string[] @description("Capabilities we prioritize")
+  max_concession_percentage float @description("Maximum we'll concede (0.0-1.0)")
+  must_have_terms string[] @description("Non-negotiable requirements")
+  nice_to_have_terms string[] @description("Preferred but negotiable terms")
+  time_sensitivity float @description("How time-sensitive we are (0.0-1.0)")
+}
+
+/// Negotiation approach style
+enum StrategyApproach {
+  COLLABORATIVE @description("Seek win-win outcomes")
+  COMPETITIVE @description("Maximize our gains")
+  ACCOMMODATING @description("Prioritize relationship over terms")
+  AVOIDING @description("Minimize conflict")
+  COMPROMISING @description("Seek middle ground quickly")
+}

--- a/src/agent_negotiation/__init__.py
+++ b/src/agent_negotiation/__init__.py
@@ -88,6 +88,48 @@ from .capability_matcher import (
     CapabilityMatcher,
 )
 
+from .negotiation_state import (
+    # Enums
+    NegotiationStatus,
+    NegotiationAction,
+    NegotiationOutcome,
+    UrgencyLevel,
+    RiskLevel,
+    StrategyApproach,
+    ConstraintType,
+    ConstraintOperator,
+    TERMINAL_STATES,
+    # Proposal types
+    NegotiationParameter,
+    SLARequirement,
+    NegotiationTerms,
+    ProposalConstraint,
+    CapabilityNegotiationItem,
+    NegotiationProposal,
+    # Turn types
+    TurnMetadata,
+    NegotiationTurn,
+    # Result types
+    NegotiationResult,
+    NegotiationContext,
+    # Identity (local copy)
+    AgentIdentity,
+    # Transition types
+    StateTransitionError,
+    StateTransitionResult,
+    # Risk types
+    RiskFactor,
+    RiskAssessment,
+    # Strategy types
+    NegotiationStrategy,
+    # State change callback type
+    StateChangeCallback,
+    # Session class
+    NegotiationSession,
+    # State machine class
+    NegotiationStateMachine,
+)
+
 __all__ = [
     # Protocol types
     "ProtocolType",
@@ -164,4 +206,42 @@ __all__ = [
     "CapabilityMatchResponse",
     # Matcher class
     "CapabilityMatcher",
+    # Negotiation status and action enums
+    "NegotiationStatus",
+    "NegotiationAction",
+    "NegotiationOutcome",
+    "UrgencyLevel",
+    "RiskLevel",
+    "StrategyApproach",
+    "ConstraintType",
+    "ConstraintOperator",
+    "TERMINAL_STATES",
+    # Proposal types
+    "NegotiationParameter",
+    "SLARequirement",
+    "NegotiationTerms",
+    "ProposalConstraint",
+    "CapabilityNegotiationItem",
+    "NegotiationProposal",
+    # Turn types
+    "TurnMetadata",
+    "NegotiationTurn",
+    # Result types
+    "NegotiationResult",
+    "NegotiationContext",
+    "AgentIdentity",
+    # Transition types
+    "StateTransitionError",
+    "StateTransitionResult",
+    # Risk types
+    "RiskFactor",
+    "RiskAssessment",
+    # Strategy types
+    "NegotiationStrategy",
+    # State change callback type
+    "StateChangeCallback",
+    # Session class
+    "NegotiationSession",
+    # State machine class
+    "NegotiationStateMachine",
 ]

--- a/src/agent_negotiation/negotiation_state.py
+++ b/src/agent_negotiation/negotiation_state.py
@@ -1,0 +1,783 @@
+"""
+Negotiation State Machine
+
+Manages state transitions for agent-to-agent negotiation sessions.
+Issue #57 - Phase 3: Agent-to-Agent Interface Negotiation (Task 3.5)
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Callable, Optional, List, Dict, Any, Set
+
+
+class NegotiationStatus(Enum):
+    """Status of a negotiation session."""
+    INITIATED = "initiated"
+    PROPOSAL_SENT = "proposal_sent"
+    COUNTER_OFFERED = "counter_offered"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    EXPIRED = "expired"
+    CANCELLED = "cancelled"
+    ADAPTED = "adapted"
+
+
+class NegotiationAction(Enum):
+    """Actions that can be taken in a negotiation."""
+    PROPOSE = "propose"
+    COUNTER = "counter"
+    ACCEPT = "accept"
+    REJECT = "reject"
+    WITHDRAW = "withdraw"
+    TIMEOUT = "timeout"
+
+
+class NegotiationOutcome(Enum):
+    """Possible negotiation outcomes."""
+    AGREEMENT = "agreement"
+    NO_AGREEMENT = "no_agreement"
+    TIMEOUT = "timeout"
+    CANCELLED = "cancelled"
+    PARTIAL_AGREEMENT = "partial_agreement"
+
+
+class UrgencyLevel(Enum):
+    """Urgency level for a negotiation."""
+    LOW = "low"
+    NORMAL = "normal"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class RiskLevel(Enum):
+    """Risk level for negotiation."""
+    LOW = "low"
+    MODERATE = "moderate"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class StrategyApproach(Enum):
+    """Negotiation approach style."""
+    COLLABORATIVE = "collaborative"
+    COMPETITIVE = "competitive"
+    ACCOMMODATING = "accommodating"
+    AVOIDING = "avoiding"
+    COMPROMISING = "compromising"
+
+
+class ConstraintType(Enum):
+    """Types of constraints."""
+    REQUIRED = "required"
+    PREFERRED = "preferred"
+    PROHIBITED = "prohibited"
+
+
+class ConstraintOperator(Enum):
+    """Comparison operators for constraints."""
+    EQUALS = "equals"
+    NOT_EQUALS = "not_equals"
+    GREATER_THAN = "greater_than"
+    LESS_THAN = "less_than"
+    CONTAINS = "contains"
+    IN = "in"
+
+
+# Terminal states - no further transitions allowed
+TERMINAL_STATES: Set[NegotiationStatus] = {
+    NegotiationStatus.ACCEPTED,
+    NegotiationStatus.REJECTED,
+    NegotiationStatus.EXPIRED,
+    NegotiationStatus.CANCELLED,
+    NegotiationStatus.ADAPTED,
+}
+
+
+@dataclass
+class NegotiationParameter:
+    """A parameter being negotiated."""
+    name: str
+    requested_value: str
+    acceptable_alternatives: Optional[List[str]] = None
+    min_value: Optional[str] = None
+    max_value: Optional[str] = None
+
+
+@dataclass
+class SLARequirement:
+    """Service level agreement requirement."""
+    metric: str
+    target_value: float
+    measurement_window_hours: int
+
+
+@dataclass
+class NegotiationTerms:
+    """Terms of a negotiation proposal."""
+    duration_hours: Optional[int] = None
+    rate_limit_per_minute: Optional[int] = None
+    priority_level: Optional[int] = None
+    billing_model: Optional[str] = None
+    sla_requirements: Optional[List[SLARequirement]] = None
+
+
+@dataclass
+class ProposalConstraint:
+    """Additional constraint on a proposal."""
+    constraint_type: ConstraintType
+    field: str
+    operator: ConstraintOperator
+    value: str
+
+
+@dataclass
+class CapabilityNegotiationItem:
+    """An item representing a capability in negotiation."""
+    capability_id: str
+    capability_name: str
+    required: bool
+    requested_level: Optional[str] = None
+    parameters: Optional[List[NegotiationParameter]] = None
+
+
+@dataclass
+class NegotiationProposal:
+    """A proposal in a negotiation session."""
+    proposal_id: str
+    capability_requirements: List[CapabilityNegotiationItem]
+    terms: NegotiationTerms
+    valid_until: str
+    constraints: Optional[List[ProposalConstraint]] = None
+
+
+@dataclass
+class TurnMetadata:
+    """Metadata for a negotiation turn."""
+    automated: bool
+    response_time_ms: Optional[int] = None
+    confidence: Optional[float] = None
+    alternatives_considered: Optional[int] = None
+
+
+@dataclass
+class NegotiationTurn:
+    """A single turn in a negotiation."""
+    turn_number: int
+    actor: str
+    action: NegotiationAction
+    timestamp: str
+    proposal: Optional[NegotiationProposal] = None
+    rationale: Optional[str] = None
+    metadata: Optional[TurnMetadata] = None
+
+
+@dataclass
+class NegotiationResult:
+    """Result of a completed negotiation."""
+    outcome: NegotiationOutcome
+    agreed_proposal: Optional[NegotiationProposal] = None
+    agreement_id: Optional[str] = None
+    effective_from: Optional[str] = None
+    effective_until: Optional[str] = None
+    rejection_reasons: Optional[List[str]] = None
+
+
+@dataclass
+class NegotiationContext:
+    """Context for a negotiation session."""
+    purpose: str
+    urgency: UrgencyLevel
+    previous_session_id: Optional[str] = None
+    tags: Optional[List[str]] = None
+    custom_data: Optional[str] = None
+
+
+@dataclass
+class AgentIdentity:
+    """Identity information for an agent."""
+    agent_id: str
+    name: str
+    version: str
+    description: str
+    provider: Optional[str] = None
+    trust_domain: Optional[str] = None
+
+
+@dataclass
+class StateTransitionError:
+    """Error details for failed state transition."""
+    error_code: str
+    message: str
+    allowed_transitions: List[NegotiationStatus]
+    suggestion: Optional[str] = None
+
+
+@dataclass
+class StateTransitionResult:
+    """Result of a state transition attempt."""
+    success: bool
+    previous_status: NegotiationStatus
+    new_status: NegotiationStatus
+    turn_number: int
+    error: Optional[StateTransitionError] = None
+    warnings: Optional[List[str]] = None
+
+
+@dataclass
+class RiskFactor:
+    """Individual risk factor."""
+    category: str
+    description: str
+    severity: RiskLevel
+    likelihood: float
+
+
+@dataclass
+class RiskAssessment:
+    """Risk assessment for a proposal."""
+    overall_risk: RiskLevel
+    factors: List[RiskFactor]
+    mitigations: Optional[List[str]] = None
+
+
+@dataclass
+class NegotiationStrategy:
+    """Negotiation strategy configuration."""
+    approach: StrategyApproach
+    priority_capabilities: List[str]
+    max_concession_percentage: float
+    must_have_terms: List[str]
+    nice_to_have_terms: List[str]
+    time_sensitivity: float
+
+
+# Type alias for state change callbacks
+StateChangeCallback = Callable[
+    [NegotiationStatus, NegotiationStatus, Optional[NegotiationTurn]], None
+]
+
+
+class NegotiationSession:
+    """A complete negotiation session between two agents."""
+
+    def __init__(
+        self,
+        session_id: str,
+        initiator: AgentIdentity,
+        responder: AgentIdentity,
+        expires_in_hours: int = 24,
+        context: Optional[NegotiationContext] = None,
+    ):
+        self.session_id = session_id
+        self.initiator = initiator
+        self.responder = responder
+        now = datetime.utcnow()
+        self.created_at = now.isoformat() + "Z"
+        self.updated_at = now.isoformat() + "Z"
+        self.expires_at = (now + timedelta(hours=expires_in_hours)).isoformat() + "Z"
+        self.status = NegotiationStatus.INITIATED
+        self.history: List[NegotiationTurn] = []
+        self.current_proposal: Optional[NegotiationProposal] = None
+        self.result: Optional[NegotiationResult] = None
+        self.context = context
+
+    @property
+    def turn_count(self) -> int:
+        """Get the number of turns in this session."""
+        return len(self.history)
+
+    @property
+    def is_terminal(self) -> bool:
+        """Check if the session is in a terminal state."""
+        return self.status in TERMINAL_STATES
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if the session has expired."""
+        if self.status == NegotiationStatus.EXPIRED:
+            return True
+        expires = datetime.fromisoformat(self.expires_at.rstrip("Z"))
+        return datetime.utcnow() > expires
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize session to dictionary."""
+        return {
+            "session_id": self.session_id,
+            "initiator": {
+                "agent_id": self.initiator.agent_id,
+                "name": self.initiator.name,
+                "version": self.initiator.version,
+                "description": self.initiator.description,
+                "provider": self.initiator.provider,
+                "trust_domain": self.initiator.trust_domain,
+            },
+            "responder": {
+                "agent_id": self.responder.agent_id,
+                "name": self.responder.name,
+                "version": self.responder.version,
+                "description": self.responder.description,
+                "provider": self.responder.provider,
+                "trust_domain": self.responder.trust_domain,
+            },
+            "status": self.status.value,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "expires_at": self.expires_at,
+            "history": [
+                {
+                    "turn_number": t.turn_number,
+                    "actor": t.actor,
+                    "action": t.action.value,
+                    "timestamp": t.timestamp,
+                    "rationale": t.rationale,
+                }
+                for t in self.history
+            ],
+            "is_terminal": self.is_terminal,
+            "turn_count": self.turn_count,
+        }
+
+
+class NegotiationStateMachine:
+    """
+    State machine for managing negotiation session transitions.
+
+    Enforces valid state transitions and maintains session history.
+
+    Valid Transitions:
+        INITIATED → PROPOSAL_SENT, CANCELLED, EXPIRED
+        PROPOSAL_SENT → COUNTER_OFFERED, ACCEPTED, REJECTED, EXPIRED
+        COUNTER_OFFERED → COUNTER_OFFERED, ACCEPTED, REJECTED, EXPIRED, ADAPTED
+
+    Terminal states (no outgoing transitions):
+        ACCEPTED, REJECTED, EXPIRED, CANCELLED, ADAPTED
+    """
+
+    # Valid state transitions
+    VALID_TRANSITIONS: Dict[NegotiationStatus, List[NegotiationStatus]] = {
+        NegotiationStatus.INITIATED: [
+            NegotiationStatus.PROPOSAL_SENT,
+            NegotiationStatus.CANCELLED,
+            NegotiationStatus.EXPIRED,  # Session can expire before proposal
+        ],
+        NegotiationStatus.PROPOSAL_SENT: [
+            NegotiationStatus.COUNTER_OFFERED,
+            NegotiationStatus.ACCEPTED,
+            NegotiationStatus.REJECTED,
+            NegotiationStatus.EXPIRED,
+        ],
+        NegotiationStatus.COUNTER_OFFERED: [
+            NegotiationStatus.COUNTER_OFFERED,  # Can have multiple counters
+            NegotiationStatus.ACCEPTED,
+            NegotiationStatus.REJECTED,
+            NegotiationStatus.EXPIRED,
+            NegotiationStatus.ADAPTED,
+        ],
+        # Terminal states have no outgoing transitions
+        NegotiationStatus.ACCEPTED: [],
+        NegotiationStatus.REJECTED: [],
+        NegotiationStatus.EXPIRED: [],
+        NegotiationStatus.CANCELLED: [],
+        NegotiationStatus.ADAPTED: [],
+    }
+
+    # Map of actions to their resulting states
+    ACTION_TO_STATUS: Dict[NegotiationAction, NegotiationStatus] = {
+        NegotiationAction.PROPOSE: NegotiationStatus.PROPOSAL_SENT,
+        NegotiationAction.COUNTER: NegotiationStatus.COUNTER_OFFERED,
+        NegotiationAction.ACCEPT: NegotiationStatus.ACCEPTED,
+        NegotiationAction.REJECT: NegotiationStatus.REJECTED,
+        NegotiationAction.WITHDRAW: NegotiationStatus.CANCELLED,
+        NegotiationAction.TIMEOUT: NegotiationStatus.EXPIRED,
+    }
+
+    def __init__(self, session: NegotiationSession):
+        """
+        Initialize state machine with a negotiation session.
+
+        Args:
+            session: The negotiation session to manage
+        """
+        self.session = session
+        self._callbacks: List[StateChangeCallback] = []
+
+    def register_callback(self, callback: StateChangeCallback) -> None:
+        """
+        Register a callback to be called on state changes.
+
+        Args:
+            callback: Function to call with (old_status, new_status, turn)
+        """
+        self._callbacks.append(callback)
+
+    def unregister_callback(self, callback: StateChangeCallback) -> None:
+        """
+        Remove a previously registered callback.
+
+        Args:
+            callback: The callback to remove
+        """
+        if callback in self._callbacks:
+            self._callbacks.remove(callback)
+
+    def can_transition(self, target: NegotiationStatus) -> bool:
+        """
+        Check if a transition to the target state is valid.
+
+        Args:
+            target: The target state to transition to
+
+        Returns:
+            True if the transition is valid, False otherwise
+        """
+        # Check expiration first
+        if self.session.is_expired and target != NegotiationStatus.EXPIRED:
+            return False
+
+        # Check if we're already in a terminal state
+        if self.session.is_terminal:
+            return False
+
+        # Check valid transitions
+        allowed = self.VALID_TRANSITIONS.get(self.session.status, [])
+        return target in allowed
+
+    def get_allowed_transitions(self) -> List[NegotiationStatus]:
+        """
+        Get list of valid target states from current state.
+
+        Returns:
+            List of valid target NegotiationStatus values
+        """
+        if self.session.is_terminal:
+            return []
+        if self.session.is_expired:
+            return [NegotiationStatus.EXPIRED]
+        return self.VALID_TRANSITIONS.get(self.session.status, [])
+
+    def transition(
+        self,
+        target: NegotiationStatus,
+        actor: str,
+        action: NegotiationAction,
+        proposal: Optional[NegotiationProposal] = None,
+        rationale: Optional[str] = None,
+        metadata: Optional[TurnMetadata] = None,
+    ) -> StateTransitionResult:
+        """
+        Attempt to transition the session to a new state.
+
+        Args:
+            target: Target state to transition to
+            actor: Agent ID of the actor taking this action
+            action: The action being taken
+            proposal: Proposal if action is PROPOSE or COUNTER
+            rationale: Optional explanation for the action
+            metadata: Optional turn metadata
+
+        Returns:
+            StateTransitionResult with success status and details
+        """
+        previous_status = self.session.status
+
+        # Validate proposal is provided for PROPOSE/COUNTER actions
+        if action in (NegotiationAction.PROPOSE, NegotiationAction.COUNTER):
+            if proposal is None:
+                return StateTransitionResult(
+                    success=False,
+                    previous_status=previous_status,
+                    new_status=previous_status,
+                    turn_number=self.session.turn_count,
+                    error=StateTransitionError(
+                        error_code="PROPOSAL_REQUIRED",
+                        message=f"A proposal is required for action {action.value}",
+                        allowed_transitions=self.get_allowed_transitions(),
+                        suggestion="Provide a NegotiationProposal with the action",
+                    ),
+                )
+
+        # Check expiration
+        if self.session.is_expired and target != NegotiationStatus.EXPIRED:
+            return StateTransitionResult(
+                success=False,
+                previous_status=previous_status,
+                new_status=previous_status,
+                turn_number=self.session.turn_count,
+                error=StateTransitionError(
+                    error_code="SESSION_EXPIRED",
+                    message="Session has expired",
+                    allowed_transitions=[NegotiationStatus.EXPIRED],
+                    suggestion="Transition to EXPIRED state or create a new session",
+                ),
+            )
+
+        # Validate transition
+        if not self.can_transition(target):
+            return StateTransitionResult(
+                success=False,
+                previous_status=previous_status,
+                new_status=previous_status,
+                turn_number=self.session.turn_count,
+                error=StateTransitionError(
+                    error_code="INVALID_TRANSITION",
+                    message=f"Cannot transition from {previous_status.value} to {target.value}",
+                    allowed_transitions=self.get_allowed_transitions(),
+                    suggestion="Choose a valid target state from the allowed transitions",
+                ),
+            )
+
+        # Validate action matches expected target
+        expected_target = self.ACTION_TO_STATUS.get(action)
+        if expected_target is not None and expected_target != target:
+            return StateTransitionResult(
+                success=False,
+                previous_status=previous_status,
+                new_status=previous_status,
+                turn_number=self.session.turn_count,
+                error=StateTransitionError(
+                    error_code="ACTION_STATUS_MISMATCH",
+                    message=f"Action {action.value} should result in {expected_target.value}, not {target.value}",
+                    allowed_transitions=self.get_allowed_transitions(),
+                    suggestion=f"Use target status {expected_target.value} with action {action.value}",
+                ),
+                warnings=[f"Action-status mismatch: {action.value} -> {target.value}"],
+            )
+
+        # Create turn
+        now = datetime.utcnow()
+        turn = NegotiationTurn(
+            turn_number=self.session.turn_count + 1,
+            actor=actor,
+            action=action,
+            timestamp=now.isoformat() + "Z",
+            proposal=proposal,
+            rationale=rationale,
+            metadata=metadata,
+        )
+
+        # Update session
+        self.session.status = target
+        self.session.updated_at = now.isoformat() + "Z"
+        self.session.history.append(turn)
+
+        # Update current proposal if applicable
+        if proposal is not None:
+            self.session.current_proposal = proposal
+
+        # Set result for terminal states
+        if target in TERMINAL_STATES:
+            self._set_result(target, proposal, rationale)
+
+        # Notify callbacks
+        for callback in self._callbacks:
+            try:
+                callback(previous_status, target, turn)
+            except Exception:
+                pass  # Don't let callback errors break the state machine
+
+        return StateTransitionResult(
+            success=True,
+            previous_status=previous_status,
+            new_status=target,
+            turn_number=turn.turn_number,
+        )
+
+    def _set_result(
+        self,
+        status: NegotiationStatus,
+        proposal: Optional[NegotiationProposal],
+        rationale: Optional[str],
+    ) -> None:
+        """Set the negotiation result based on terminal status."""
+        outcome_map = {
+            NegotiationStatus.ACCEPTED: NegotiationOutcome.AGREEMENT,
+            NegotiationStatus.REJECTED: NegotiationOutcome.NO_AGREEMENT,
+            NegotiationStatus.EXPIRED: NegotiationOutcome.TIMEOUT,
+            NegotiationStatus.CANCELLED: NegotiationOutcome.CANCELLED,
+            NegotiationStatus.ADAPTED: NegotiationOutcome.PARTIAL_AGREEMENT,
+        }
+
+        outcome = outcome_map.get(status, NegotiationOutcome.NO_AGREEMENT)
+
+        self.session.result = NegotiationResult(
+            outcome=outcome,
+            agreed_proposal=proposal if status == NegotiationStatus.ACCEPTED else None,
+            rejection_reasons=[rationale] if status == NegotiationStatus.REJECTED and rationale else None,
+        )
+
+    def expire_if_needed(self) -> Optional[StateTransitionResult]:
+        """
+        Check if session should be expired and transition if so.
+
+        Returns:
+            StateTransitionResult if expired, None otherwise
+        """
+        if self.session.is_expired and self.session.status != NegotiationStatus.EXPIRED:
+            return self.transition(
+                target=NegotiationStatus.EXPIRED,
+                actor="system",
+                action=NegotiationAction.TIMEOUT,
+                rationale="Session expired due to timeout",
+                metadata=TurnMetadata(automated=True),
+            )
+        return None
+
+    def propose(
+        self,
+        actor: str,
+        proposal: NegotiationProposal,
+        rationale: Optional[str] = None,
+    ) -> StateTransitionResult:
+        """
+        Submit an initial proposal.
+
+        Args:
+            actor: Agent ID making the proposal
+            proposal: The proposal to submit
+            rationale: Optional explanation
+
+        Returns:
+            StateTransitionResult with success status
+        """
+        return self.transition(
+            target=NegotiationStatus.PROPOSAL_SENT,
+            actor=actor,
+            action=NegotiationAction.PROPOSE,
+            proposal=proposal,
+            rationale=rationale,
+        )
+
+    def counter(
+        self,
+        actor: str,
+        proposal: NegotiationProposal,
+        rationale: Optional[str] = None,
+    ) -> StateTransitionResult:
+        """
+        Submit a counter-proposal.
+
+        Args:
+            actor: Agent ID making the counter
+            proposal: The counter-proposal
+            rationale: Optional explanation
+
+        Returns:
+            StateTransitionResult with success status
+        """
+        return self.transition(
+            target=NegotiationStatus.COUNTER_OFFERED,
+            actor=actor,
+            action=NegotiationAction.COUNTER,
+            proposal=proposal,
+            rationale=rationale,
+        )
+
+    def accept(
+        self,
+        actor: str,
+        rationale: Optional[str] = None,
+    ) -> StateTransitionResult:
+        """
+        Accept the current proposal.
+
+        Args:
+            actor: Agent ID accepting
+            rationale: Optional explanation
+
+        Returns:
+            StateTransitionResult with success status
+        """
+        return self.transition(
+            target=NegotiationStatus.ACCEPTED,
+            actor=actor,
+            action=NegotiationAction.ACCEPT,
+            proposal=self.session.current_proposal,
+            rationale=rationale,
+        )
+
+    def reject(
+        self,
+        actor: str,
+        rationale: Optional[str] = None,
+    ) -> StateTransitionResult:
+        """
+        Reject the current proposal.
+
+        Args:
+            actor: Agent ID rejecting
+            rationale: Explanation for rejection
+
+        Returns:
+            StateTransitionResult with success status
+        """
+        return self.transition(
+            target=NegotiationStatus.REJECTED,
+            actor=actor,
+            action=NegotiationAction.REJECT,
+            rationale=rationale,
+        )
+
+    def withdraw(
+        self,
+        actor: str,
+        rationale: Optional[str] = None,
+    ) -> StateTransitionResult:
+        """
+        Withdraw from the negotiation.
+
+        Args:
+            actor: Agent ID withdrawing
+            rationale: Optional explanation
+
+        Returns:
+            StateTransitionResult with success status
+        """
+        # Withdraw can only happen from INITIATED state
+        if self.session.status != NegotiationStatus.INITIATED:
+            return StateTransitionResult(
+                success=False,
+                previous_status=self.session.status,
+                new_status=self.session.status,
+                turn_number=self.session.turn_count,
+                error=StateTransitionError(
+                    error_code="INVALID_WITHDRAW",
+                    message="Can only withdraw from INITIATED state",
+                    allowed_transitions=self.get_allowed_transitions(),
+                    suggestion="Use reject instead to end the negotiation",
+                ),
+            )
+
+        return self.transition(
+            target=NegotiationStatus.CANCELLED,
+            actor=actor,
+            action=NegotiationAction.WITHDRAW,
+            rationale=rationale,
+        )
+
+    def get_session_summary(self) -> Dict[str, Any]:
+        """
+        Get a summary of the current session state.
+
+        Returns:
+            Dictionary with session summary
+        """
+        return {
+            "session_id": self.session.session_id,
+            "status": self.session.status.value,
+            "turn_count": self.session.turn_count,
+            "is_terminal": self.session.is_terminal,
+            "is_expired": self.session.is_expired,
+            "allowed_transitions": [s.value for s in self.get_allowed_transitions()],
+            "current_proposal_id": (
+                self.session.current_proposal.proposal_id
+                if self.session.current_proposal
+                else None
+            ),
+            "last_actor": (
+                self.session.history[-1].actor if self.session.history else None
+            ),
+            "last_action": (
+                self.session.history[-1].action.value if self.session.history else None
+            ),
+        }

--- a/tests/test_negotiation_state.py
+++ b/tests/test_negotiation_state.py
@@ -1,0 +1,1322 @@
+"""
+Tests for Negotiation State Machine
+
+Issue #57 - Phase 3: Agent-to-Agent Interface Negotiation (Task 3.5)
+"""
+
+import pytest
+from datetime import datetime, timedelta
+from typing import Optional
+
+from src.agent_negotiation import (
+    # Enums
+    NegotiationStatus,
+    NegotiationAction,
+    NegotiationOutcome,
+    UrgencyLevel,
+    RiskLevel,
+    StrategyApproach,
+    ConstraintType,
+    ConstraintOperator,
+    TERMINAL_STATES,
+    # Proposal types
+    NegotiationParameter,
+    SLARequirement,
+    NegotiationTerms,
+    ProposalConstraint,
+    CapabilityNegotiationItem,
+    NegotiationProposal,
+    # Turn types
+    TurnMetadata,
+    NegotiationTurn,
+    # Result types
+    NegotiationResult,
+    NegotiationContext,
+    AgentIdentity,
+    # Transition types
+    StateTransitionError,
+    StateTransitionResult,
+    # Risk types
+    RiskFactor,
+    RiskAssessment,
+    # Strategy types
+    NegotiationStrategy,
+    # State change callback type
+    StateChangeCallback,
+    # Session class
+    NegotiationSession,
+    # State machine class
+    NegotiationStateMachine,
+)
+
+
+# ============================================
+# Fixtures
+# ============================================
+
+
+@pytest.fixture
+def initiator() -> AgentIdentity:
+    """Create an initiator agent identity."""
+    return AgentIdentity(
+        agent_id="urn:agent:acme:planner:1.0.0",
+        name="Acme Planner",
+        version="1.0.0",
+        description="A planning agent for task orchestration",
+        provider="Acme Corp",
+    )
+
+
+@pytest.fixture
+def responder() -> AgentIdentity:
+    """Create a responder agent identity."""
+    return AgentIdentity(
+        agent_id="urn:agent:widgets:executor:2.0.0",
+        name="Widget Executor",
+        version="2.0.0",
+        description="An execution agent for widget operations",
+        provider="Widget Inc",
+    )
+
+
+@pytest.fixture
+def session(initiator: AgentIdentity, responder: AgentIdentity) -> NegotiationSession:
+    """Create a basic negotiation session."""
+    return NegotiationSession(
+        session_id="test-session-001",
+        initiator=initiator,
+        responder=responder,
+        expires_in_hours=24,
+    )
+
+
+@pytest.fixture
+def state_machine(session: NegotiationSession) -> NegotiationStateMachine:
+    """Create a state machine for the session."""
+    return NegotiationStateMachine(session)
+
+
+@pytest.fixture
+def sample_proposal() -> NegotiationProposal:
+    """Create a sample proposal."""
+    return NegotiationProposal(
+        proposal_id="proposal-001",
+        capability_requirements=[
+            CapabilityNegotiationItem(
+                capability_id="cap-task-exec",
+                capability_name="Task Execution",
+                required=True,
+                requested_level="full",
+                parameters=[
+                    NegotiationParameter(
+                        name="max_concurrent",
+                        requested_value="10",
+                        min_value="5",
+                        max_value="20",
+                    )
+                ],
+            ),
+        ],
+        terms=NegotiationTerms(
+            duration_hours=720,  # 30 days
+            rate_limit_per_minute=100,
+            priority_level=5,
+            billing_model="per_call",
+        ),
+        valid_until=(datetime.utcnow() + timedelta(hours=24)).isoformat() + "Z",
+    )
+
+
+@pytest.fixture
+def counter_proposal() -> NegotiationProposal:
+    """Create a counter-proposal."""
+    return NegotiationProposal(
+        proposal_id="proposal-002",
+        capability_requirements=[
+            CapabilityNegotiationItem(
+                capability_id="cap-task-exec",
+                capability_name="Task Execution",
+                required=True,
+                requested_level="limited",
+                parameters=[
+                    NegotiationParameter(
+                        name="max_concurrent",
+                        requested_value="7",
+                        min_value="5",
+                        max_value="10",
+                    )
+                ],
+            ),
+        ],
+        terms=NegotiationTerms(
+            duration_hours=360,  # 15 days
+            rate_limit_per_minute=50,
+            priority_level=3,
+            billing_model="per_call",
+        ),
+        valid_until=(datetime.utcnow() + timedelta(hours=24)).isoformat() + "Z",
+    )
+
+
+# ============================================
+# Test Enums
+# ============================================
+
+
+class TestNegotiationStatus:
+    """Tests for NegotiationStatus enum."""
+
+    def test_all_statuses_defined(self):
+        """Verify all expected statuses are defined."""
+        expected = {
+            "INITIATED",
+            "PROPOSAL_SENT",
+            "COUNTER_OFFERED",
+            "ACCEPTED",
+            "REJECTED",
+            "EXPIRED",
+            "CANCELLED",
+            "ADAPTED",
+        }
+        actual = {s.name for s in NegotiationStatus}
+        assert actual == expected
+
+    def test_terminal_states(self):
+        """Verify terminal states are correctly defined."""
+        assert NegotiationStatus.ACCEPTED in TERMINAL_STATES
+        assert NegotiationStatus.REJECTED in TERMINAL_STATES
+        assert NegotiationStatus.EXPIRED in TERMINAL_STATES
+        assert NegotiationStatus.CANCELLED in TERMINAL_STATES
+        assert NegotiationStatus.ADAPTED in TERMINAL_STATES
+        assert NegotiationStatus.INITIATED not in TERMINAL_STATES
+        assert NegotiationStatus.PROPOSAL_SENT not in TERMINAL_STATES
+        assert NegotiationStatus.COUNTER_OFFERED not in TERMINAL_STATES
+
+
+class TestNegotiationAction:
+    """Tests for NegotiationAction enum."""
+
+    def test_all_actions_defined(self):
+        """Verify all expected actions are defined."""
+        expected = {"PROPOSE", "COUNTER", "ACCEPT", "REJECT", "WITHDRAW", "TIMEOUT"}
+        actual = {a.name for a in NegotiationAction}
+        assert actual == expected
+
+
+class TestOtherEnums:
+    """Tests for other enums."""
+
+    def test_negotiation_outcome(self):
+        """Verify NegotiationOutcome enum."""
+        assert NegotiationOutcome.AGREEMENT.value == "agreement"
+        assert NegotiationOutcome.NO_AGREEMENT.value == "no_agreement"
+        assert NegotiationOutcome.TIMEOUT.value == "timeout"
+        assert NegotiationOutcome.CANCELLED.value == "cancelled"
+        assert NegotiationOutcome.PARTIAL_AGREEMENT.value == "partial_agreement"
+
+    def test_urgency_level(self):
+        """Verify UrgencyLevel enum."""
+        levels = [UrgencyLevel.LOW, UrgencyLevel.NORMAL, UrgencyLevel.HIGH, UrgencyLevel.CRITICAL]
+        assert len(levels) == 4
+
+    def test_risk_level(self):
+        """Verify RiskLevel enum."""
+        levels = [RiskLevel.LOW, RiskLevel.MODERATE, RiskLevel.HIGH, RiskLevel.CRITICAL]
+        assert len(levels) == 4
+
+    def test_strategy_approach(self):
+        """Verify StrategyApproach enum."""
+        approaches = [
+            StrategyApproach.COLLABORATIVE,
+            StrategyApproach.COMPETITIVE,
+            StrategyApproach.ACCOMMODATING,
+            StrategyApproach.AVOIDING,
+            StrategyApproach.COMPROMISING,
+        ]
+        assert len(approaches) == 5
+
+
+# ============================================
+# Test Data Classes
+# ============================================
+
+
+class TestNegotiationParameter:
+    """Tests for NegotiationParameter dataclass."""
+
+    def test_basic_creation(self):
+        """Test creating a negotiation parameter."""
+        param = NegotiationParameter(
+            name="timeout",
+            requested_value="30",
+        )
+        assert param.name == "timeout"
+        assert param.requested_value == "30"
+        assert param.acceptable_alternatives is None
+        assert param.min_value is None
+        assert param.max_value is None
+
+    def test_full_creation(self):
+        """Test creating with all fields."""
+        param = NegotiationParameter(
+            name="rate_limit",
+            requested_value="100",
+            acceptable_alternatives=["50", "75", "150"],
+            min_value="10",
+            max_value="200",
+        )
+        assert param.acceptable_alternatives == ["50", "75", "150"]
+        assert param.min_value == "10"
+        assert param.max_value == "200"
+
+
+class TestNegotiationTerms:
+    """Tests for NegotiationTerms dataclass."""
+
+    def test_empty_terms(self):
+        """Test creating empty terms."""
+        terms = NegotiationTerms()
+        assert terms.duration_hours is None
+        assert terms.rate_limit_per_minute is None
+        assert terms.priority_level is None
+        assert terms.billing_model is None
+        assert terms.sla_requirements is None
+
+    def test_full_terms(self):
+        """Test creating full terms."""
+        sla = SLARequirement(
+            metric="response_time_ms",
+            target_value=100.0,
+            measurement_window_hours=24,
+        )
+        terms = NegotiationTerms(
+            duration_hours=720,
+            rate_limit_per_minute=100,
+            priority_level=5,
+            billing_model="per_call",
+            sla_requirements=[sla],
+        )
+        assert terms.duration_hours == 720
+        assert terms.sla_requirements[0].metric == "response_time_ms"
+
+
+class TestProposalConstraint:
+    """Tests for ProposalConstraint dataclass."""
+
+    def test_required_constraint(self):
+        """Test creating a required constraint."""
+        constraint = ProposalConstraint(
+            constraint_type=ConstraintType.REQUIRED,
+            field="protocol",
+            operator=ConstraintOperator.EQUALS,
+            value="A2A",
+        )
+        assert constraint.constraint_type == ConstraintType.REQUIRED
+        assert constraint.operator == ConstraintOperator.EQUALS
+
+    def test_prohibited_constraint(self):
+        """Test creating a prohibited constraint."""
+        constraint = ProposalConstraint(
+            constraint_type=ConstraintType.PROHIBITED,
+            field="data_region",
+            operator=ConstraintOperator.IN,
+            value="CN,RU",
+        )
+        assert constraint.constraint_type == ConstraintType.PROHIBITED
+
+
+class TestNegotiationProposal:
+    """Tests for NegotiationProposal dataclass."""
+
+    def test_basic_proposal(self, sample_proposal: NegotiationProposal):
+        """Test basic proposal creation."""
+        assert sample_proposal.proposal_id == "proposal-001"
+        assert len(sample_proposal.capability_requirements) == 1
+        assert sample_proposal.capability_requirements[0].capability_id == "cap-task-exec"
+        assert sample_proposal.terms.duration_hours == 720
+
+
+class TestTurnMetadata:
+    """Tests for TurnMetadata dataclass."""
+
+    def test_minimal_metadata(self):
+        """Test creating minimal metadata."""
+        meta = TurnMetadata(automated=False)
+        assert meta.automated is False
+        assert meta.response_time_ms is None
+
+    def test_full_metadata(self):
+        """Test creating full metadata."""
+        meta = TurnMetadata(
+            automated=True,
+            response_time_ms=150,
+            confidence=0.95,
+            alternatives_considered=3,
+        )
+        assert meta.automated is True
+        assert meta.response_time_ms == 150
+        assert meta.confidence == 0.95
+
+
+class TestNegotiationTurn:
+    """Tests for NegotiationTurn dataclass."""
+
+    def test_basic_turn(self):
+        """Test creating a basic turn."""
+        turn = NegotiationTurn(
+            turn_number=1,
+            actor="agent-001",
+            action=NegotiationAction.PROPOSE,
+            timestamp=datetime.utcnow().isoformat() + "Z",
+        )
+        assert turn.turn_number == 1
+        assert turn.action == NegotiationAction.PROPOSE
+        assert turn.proposal is None
+
+
+class TestNegotiationContext:
+    """Tests for NegotiationContext dataclass."""
+
+    def test_basic_context(self):
+        """Test creating basic context."""
+        context = NegotiationContext(
+            purpose="Task delegation",
+            urgency=UrgencyLevel.NORMAL,
+        )
+        assert context.purpose == "Task delegation"
+        assert context.urgency == UrgencyLevel.NORMAL
+
+    def test_full_context(self):
+        """Test creating full context."""
+        context = NegotiationContext(
+            purpose="Emergency response",
+            urgency=UrgencyLevel.CRITICAL,
+            previous_session_id="prev-session-001",
+            tags=["emergency", "high-priority"],
+            custom_data='{"incident_id": "INC-123"}',
+        )
+        assert context.tags == ["emergency", "high-priority"]
+
+
+# ============================================
+# Test NegotiationSession
+# ============================================
+
+
+class TestNegotiationSession:
+    """Tests for NegotiationSession class."""
+
+    def test_session_creation(self, session: NegotiationSession):
+        """Test basic session creation."""
+        assert session.session_id == "test-session-001"
+        assert session.status == NegotiationStatus.INITIATED
+        assert session.turn_count == 0
+        assert session.is_terminal is False
+        assert session.current_proposal is None
+        assert session.result is None
+
+    def test_session_with_context(
+        self, initiator: AgentIdentity, responder: AgentIdentity
+    ):
+        """Test session with context."""
+        context = NegotiationContext(
+            purpose="API access",
+            urgency=UrgencyLevel.HIGH,
+        )
+        session = NegotiationSession(
+            session_id="ctx-session-001",
+            initiator=initiator,
+            responder=responder,
+            context=context,
+        )
+        assert session.context is not None
+        assert session.context.purpose == "API access"
+
+    def test_session_expiration(
+        self, initiator: AgentIdentity, responder: AgentIdentity
+    ):
+        """Test session expiration detection."""
+        # Create session that expires in -1 hours (already expired)
+        session = NegotiationSession(
+            session_id="expired-session",
+            initiator=initiator,
+            responder=responder,
+            expires_in_hours=-1,
+        )
+        assert session.is_expired is True
+
+    def test_session_not_expired(self, session: NegotiationSession):
+        """Test session is not expired when valid."""
+        assert session.is_expired is False
+
+    def test_session_to_dict(self, session: NegotiationSession):
+        """Test session serialization."""
+        data = session.to_dict()
+        assert data["session_id"] == "test-session-001"
+        assert data["status"] == "initiated"
+        assert data["is_terminal"] is False
+        assert data["turn_count"] == 0
+        assert "initiator" in data
+        assert data["initiator"]["agent_id"] == "urn:agent:acme:planner:1.0.0"
+
+
+# ============================================
+# Test NegotiationStateMachine
+# ============================================
+
+
+class TestStateMachineCreation:
+    """Tests for state machine creation."""
+
+    def test_basic_creation(self, state_machine: NegotiationStateMachine):
+        """Test basic state machine creation."""
+        assert state_machine.session is not None
+        assert state_machine.session.status == NegotiationStatus.INITIATED
+
+    def test_initial_allowed_transitions(self, state_machine: NegotiationStateMachine):
+        """Test initial allowed transitions."""
+        allowed = state_machine.get_allowed_transitions()
+        assert NegotiationStatus.PROPOSAL_SENT in allowed
+        assert NegotiationStatus.CANCELLED in allowed
+        assert NegotiationStatus.EXPIRED in allowed
+        assert len(allowed) == 3
+
+
+class TestValidTransitions:
+    """Tests for valid state transition matrix."""
+
+    def test_valid_transitions_from_initiated(self):
+        """Verify valid transitions from INITIATED."""
+        valid = NegotiationStateMachine.VALID_TRANSITIONS[NegotiationStatus.INITIATED]
+        assert NegotiationStatus.PROPOSAL_SENT in valid
+        assert NegotiationStatus.CANCELLED in valid
+        assert NegotiationStatus.EXPIRED in valid
+        assert len(valid) == 3
+
+    def test_valid_transitions_from_proposal_sent(self):
+        """Verify valid transitions from PROPOSAL_SENT."""
+        valid = NegotiationStateMachine.VALID_TRANSITIONS[NegotiationStatus.PROPOSAL_SENT]
+        assert NegotiationStatus.COUNTER_OFFERED in valid
+        assert NegotiationStatus.ACCEPTED in valid
+        assert NegotiationStatus.REJECTED in valid
+        assert NegotiationStatus.EXPIRED in valid
+
+    def test_valid_transitions_from_counter_offered(self):
+        """Verify valid transitions from COUNTER_OFFERED."""
+        valid = NegotiationStateMachine.VALID_TRANSITIONS[NegotiationStatus.COUNTER_OFFERED]
+        assert NegotiationStatus.COUNTER_OFFERED in valid  # Can counter again
+        assert NegotiationStatus.ACCEPTED in valid
+        assert NegotiationStatus.REJECTED in valid
+        assert NegotiationStatus.EXPIRED in valid
+        assert NegotiationStatus.ADAPTED in valid
+
+    def test_terminal_states_have_no_transitions(self):
+        """Verify terminal states have no outgoing transitions."""
+        for status in TERMINAL_STATES:
+            valid = NegotiationStateMachine.VALID_TRANSITIONS[status]
+            assert len(valid) == 0
+
+
+class TestCanTransition:
+    """Tests for can_transition method."""
+
+    def test_can_transition_valid(self, state_machine: NegotiationStateMachine):
+        """Test can_transition returns True for valid transition."""
+        assert state_machine.can_transition(NegotiationStatus.PROPOSAL_SENT) is True
+        assert state_machine.can_transition(NegotiationStatus.CANCELLED) is True
+
+    def test_can_transition_invalid(self, state_machine: NegotiationStateMachine):
+        """Test can_transition returns False for invalid transition."""
+        assert state_machine.can_transition(NegotiationStatus.ACCEPTED) is False
+        assert state_machine.can_transition(NegotiationStatus.COUNTER_OFFERED) is False
+
+    def test_can_transition_from_terminal(
+        self,
+        state_machine: NegotiationStateMachine,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test cannot transition from terminal state."""
+        # First make a proposal
+        state_machine.propose(
+            actor="agent-001",
+            proposal=sample_proposal,
+        )
+        # Then accept
+        state_machine.accept(actor="agent-002")
+        # Now in terminal state
+        assert state_machine.session.status == NegotiationStatus.ACCEPTED
+        assert state_machine.can_transition(NegotiationStatus.REJECTED) is False
+        assert state_machine.get_allowed_transitions() == []
+
+
+class TestPropose:
+    """Tests for propose method."""
+
+    def test_propose_success(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test successful proposal."""
+        result = state_machine.propose(
+            actor=initiator.agent_id,
+            proposal=sample_proposal,
+            rationale="Initial capability request",
+        )
+        assert result.success is True
+        assert result.previous_status == NegotiationStatus.INITIATED
+        assert result.new_status == NegotiationStatus.PROPOSAL_SENT
+        assert result.turn_number == 1
+        assert state_machine.session.current_proposal == sample_proposal
+        assert len(state_machine.session.history) == 1
+
+    def test_propose_without_proposal(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+    ):
+        """Test propose fails without proposal."""
+        result = state_machine.transition(
+            target=NegotiationStatus.PROPOSAL_SENT,
+            actor=initiator.agent_id,
+            action=NegotiationAction.PROPOSE,
+            proposal=None,
+        )
+        assert result.success is False
+        assert result.error is not None
+        assert result.error.error_code == "PROPOSAL_REQUIRED"
+
+    def test_propose_from_wrong_state(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test propose fails from wrong state."""
+        # First make a proposal
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+        # Try to propose again (should fail)
+        result = state_machine.propose(
+            actor=initiator.agent_id,
+            proposal=sample_proposal,
+        )
+        assert result.success is False
+        assert result.error.error_code == "INVALID_TRANSITION"
+
+
+class TestCounter:
+    """Tests for counter method."""
+
+    def test_counter_success(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        responder: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+        counter_proposal: NegotiationProposal,
+    ):
+        """Test successful counter-proposal."""
+        # First make a proposal
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+
+        # Then counter
+        result = state_machine.counter(
+            actor=responder.agent_id,
+            proposal=counter_proposal,
+            rationale="Adjusting rate limits",
+        )
+        assert result.success is True
+        assert result.new_status == NegotiationStatus.COUNTER_OFFERED
+        assert result.turn_number == 2
+        assert state_machine.session.current_proposal == counter_proposal
+
+    def test_multiple_counters(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        responder: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+        counter_proposal: NegotiationProposal,
+    ):
+        """Test multiple counter-proposals."""
+        # Propose -> Counter -> Counter
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+        state_machine.counter(actor=responder.agent_id, proposal=counter_proposal)
+
+        # Another counter
+        another_counter = NegotiationProposal(
+            proposal_id="proposal-003",
+            capability_requirements=counter_proposal.capability_requirements,
+            terms=NegotiationTerms(
+                duration_hours=500,
+                rate_limit_per_minute=75,
+            ),
+            valid_until=counter_proposal.valid_until,
+        )
+        result = state_machine.counter(
+            actor=initiator.agent_id,
+            proposal=another_counter,
+        )
+        assert result.success is True
+        assert result.turn_number == 3
+        assert state_machine.session.status == NegotiationStatus.COUNTER_OFFERED
+
+    def test_counter_from_initiated_fails(
+        self,
+        state_machine: NegotiationStateMachine,
+        responder: AgentIdentity,
+        counter_proposal: NegotiationProposal,
+    ):
+        """Test counter fails from INITIATED state."""
+        result = state_machine.counter(
+            actor=responder.agent_id,
+            proposal=counter_proposal,
+        )
+        assert result.success is False
+        assert result.error.error_code == "INVALID_TRANSITION"
+
+
+class TestAccept:
+    """Tests for accept method."""
+
+    def test_accept_after_proposal(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        responder: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test accepting after proposal."""
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+
+        result = state_machine.accept(
+            actor=responder.agent_id,
+            rationale="Terms are acceptable",
+        )
+        assert result.success is True
+        assert result.new_status == NegotiationStatus.ACCEPTED
+        assert state_machine.session.is_terminal is True
+        assert state_machine.session.result is not None
+        assert state_machine.session.result.outcome == NegotiationOutcome.AGREEMENT
+
+    def test_accept_after_counter(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        responder: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+        counter_proposal: NegotiationProposal,
+    ):
+        """Test accepting after counter."""
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+        state_machine.counter(actor=responder.agent_id, proposal=counter_proposal)
+
+        result = state_machine.accept(actor=initiator.agent_id)
+        assert result.success is True
+        assert result.new_status == NegotiationStatus.ACCEPTED
+
+    def test_accept_from_initiated_fails(
+        self,
+        state_machine: NegotiationStateMachine,
+        responder: AgentIdentity,
+    ):
+        """Test accept fails from INITIATED state."""
+        result = state_machine.accept(actor=responder.agent_id)
+        assert result.success is False
+
+
+class TestReject:
+    """Tests for reject method."""
+
+    def test_reject_after_proposal(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        responder: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test rejecting after proposal."""
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+
+        result = state_machine.reject(
+            actor=responder.agent_id,
+            rationale="Terms are unacceptable",
+        )
+        assert result.success is True
+        assert result.new_status == NegotiationStatus.REJECTED
+        assert state_machine.session.is_terminal is True
+        assert state_machine.session.result is not None
+        assert state_machine.session.result.outcome == NegotiationOutcome.NO_AGREEMENT
+        assert state_machine.session.result.rejection_reasons == ["Terms are unacceptable"]
+
+    def test_reject_after_counter(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        responder: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+        counter_proposal: NegotiationProposal,
+    ):
+        """Test rejecting after counter."""
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+        state_machine.counter(actor=responder.agent_id, proposal=counter_proposal)
+
+        result = state_machine.reject(actor=initiator.agent_id)
+        assert result.success is True
+        assert result.new_status == NegotiationStatus.REJECTED
+
+
+class TestWithdraw:
+    """Tests for withdraw method."""
+
+    def test_withdraw_from_initiated(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+    ):
+        """Test withdrawing from INITIATED state."""
+        result = state_machine.withdraw(
+            actor=initiator.agent_id,
+            rationale="Changed requirements",
+        )
+        assert result.success is True
+        assert result.new_status == NegotiationStatus.CANCELLED
+        assert state_machine.session.is_terminal is True
+        assert state_machine.session.result.outcome == NegotiationOutcome.CANCELLED
+
+    def test_withdraw_from_proposal_sent_fails(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test withdraw fails after proposal sent."""
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+
+        result = state_machine.withdraw(actor=initiator.agent_id)
+        assert result.success is False
+        assert result.error.error_code == "INVALID_WITHDRAW"
+
+
+class TestExpiration:
+    """Tests for session expiration handling."""
+
+    def test_expire_if_needed(
+        self, initiator: AgentIdentity, responder: AgentIdentity
+    ):
+        """Test automatic expiration."""
+        session = NegotiationSession(
+            session_id="expiring-session",
+            initiator=initiator,
+            responder=responder,
+            expires_in_hours=-1,  # Already expired
+        )
+        state_machine = NegotiationStateMachine(session)
+
+        result = state_machine.expire_if_needed()
+        assert result is not None
+        assert result.success is True
+        assert result.new_status == NegotiationStatus.EXPIRED
+        assert session.result.outcome == NegotiationOutcome.TIMEOUT
+
+    def test_no_expire_if_valid(self, state_machine: NegotiationStateMachine):
+        """Test no expiration if session is valid."""
+        result = state_machine.expire_if_needed()
+        assert result is None
+
+    def test_cannot_transition_if_expired(
+        self,
+        initiator: AgentIdentity,
+        responder: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test cannot make normal transition if expired."""
+        session = NegotiationSession(
+            session_id="expired-session",
+            initiator=initiator,
+            responder=responder,
+            expires_in_hours=-1,
+        )
+        state_machine = NegotiationStateMachine(session)
+
+        result = state_machine.propose(
+            actor=initiator.agent_id,
+            proposal=sample_proposal,
+        )
+        assert result.success is False
+        assert result.error.error_code == "SESSION_EXPIRED"
+
+
+class TestCallbacks:
+    """Tests for state change callbacks."""
+
+    def test_callback_on_transition(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test callback is called on state transition."""
+        callback_data = []
+
+        def callback(
+            old: NegotiationStatus,
+            new: NegotiationStatus,
+            turn: Optional[NegotiationTurn],
+        ):
+            callback_data.append((old, new, turn))
+
+        state_machine.register_callback(callback)
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+
+        assert len(callback_data) == 1
+        assert callback_data[0][0] == NegotiationStatus.INITIATED
+        assert callback_data[0][1] == NegotiationStatus.PROPOSAL_SENT
+        assert callback_data[0][2].turn_number == 1
+
+    def test_multiple_callbacks(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test multiple callbacks are called."""
+        call_count = [0, 0]
+
+        def callback1(old, new, turn):
+            call_count[0] += 1
+
+        def callback2(old, new, turn):
+            call_count[1] += 1
+
+        state_machine.register_callback(callback1)
+        state_machine.register_callback(callback2)
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+
+        assert call_count[0] == 1
+        assert call_count[1] == 1
+
+    def test_unregister_callback(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test unregistering a callback."""
+        call_count = [0]
+
+        def callback(old, new, turn):
+            call_count[0] += 1
+
+        state_machine.register_callback(callback)
+        state_machine.unregister_callback(callback)
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+
+        assert call_count[0] == 0
+
+    def test_callback_error_handled(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test callback errors don't break state machine."""
+
+        def bad_callback(old, new, turn):
+            raise ValueError("Callback error")
+
+        state_machine.register_callback(bad_callback)
+
+        # Should not raise
+        result = state_machine.propose(
+            actor=initiator.agent_id,
+            proposal=sample_proposal,
+        )
+        assert result.success is True
+
+
+class TestSessionSummary:
+    """Tests for get_session_summary method."""
+
+    def test_initial_summary(self, state_machine: NegotiationStateMachine):
+        """Test summary for initial state."""
+        summary = state_machine.get_session_summary()
+        assert summary["session_id"] == "test-session-001"
+        assert summary["status"] == "initiated"
+        assert summary["turn_count"] == 0
+        assert summary["is_terminal"] is False
+        assert summary["current_proposal_id"] is None
+        assert summary["last_actor"] is None
+
+    def test_summary_after_proposal(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test summary after proposal."""
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+
+        summary = state_machine.get_session_summary()
+        assert summary["status"] == "proposal_sent"
+        assert summary["turn_count"] == 1
+        assert summary["current_proposal_id"] == "proposal-001"
+        assert summary["last_actor"] == initiator.agent_id
+        assert summary["last_action"] == "propose"
+
+    def test_summary_after_acceptance(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        responder: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test summary after acceptance."""
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+        state_machine.accept(actor=responder.agent_id)
+
+        summary = state_machine.get_session_summary()
+        assert summary["status"] == "accepted"
+        assert summary["is_terminal"] is True
+        assert summary["allowed_transitions"] == []
+
+
+class TestActionStatusMapping:
+    """Tests for action to status mapping."""
+
+    def test_action_status_mismatch(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test action-status mismatch is rejected."""
+        result = state_machine.transition(
+            target=NegotiationStatus.CANCELLED,  # Wrong target for PROPOSE action
+            actor=initiator.agent_id,
+            action=NegotiationAction.PROPOSE,
+            proposal=sample_proposal,
+        )
+        assert result.success is False
+        assert result.error.error_code == "ACTION_STATUS_MISMATCH"
+
+
+class TestComplexScenarios:
+    """Tests for complex negotiation scenarios."""
+
+    def test_full_negotiation_flow(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        responder: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+        counter_proposal: NegotiationProposal,
+    ):
+        """Test complete negotiation flow: propose -> counter -> counter -> accept."""
+        # Initiator proposes
+        r1 = state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+        assert r1.success is True
+
+        # Responder counters
+        r2 = state_machine.counter(actor=responder.agent_id, proposal=counter_proposal)
+        assert r2.success is True
+
+        # Initiator counters again
+        final_proposal = NegotiationProposal(
+            proposal_id="proposal-final",
+            capability_requirements=counter_proposal.capability_requirements,
+            terms=NegotiationTerms(
+                duration_hours=540,  # Compromise
+                rate_limit_per_minute=75,  # Compromise
+            ),
+            valid_until=sample_proposal.valid_until,
+        )
+        r3 = state_machine.counter(actor=initiator.agent_id, proposal=final_proposal)
+        assert r3.success is True
+
+        # Responder accepts
+        r4 = state_machine.accept(actor=responder.agent_id, rationale="Agreed on terms")
+        assert r4.success is True
+
+        # Verify final state
+        assert state_machine.session.status == NegotiationStatus.ACCEPTED
+        assert state_machine.session.turn_count == 4
+        assert state_machine.session.result.outcome == NegotiationOutcome.AGREEMENT
+
+    def test_negotiation_rejection_flow(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        responder: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+        counter_proposal: NegotiationProposal,
+    ):
+        """Test negotiation ending in rejection."""
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+        state_machine.counter(actor=responder.agent_id, proposal=counter_proposal)
+
+        result = state_machine.reject(
+            actor=initiator.agent_id,
+            rationale="Cannot meet counter-proposal terms",
+        )
+        assert result.success is True
+        assert state_machine.session.result.outcome == NegotiationOutcome.NO_AGREEMENT
+
+    def test_early_withdrawal(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+    ):
+        """Test early withdrawal before any proposal."""
+        result = state_machine.withdraw(
+            actor=initiator.agent_id,
+            rationale="Requirements changed",
+        )
+        assert result.success is True
+        assert state_machine.session.status == NegotiationStatus.CANCELLED
+        assert state_machine.session.turn_count == 1
+
+
+class TestHistoryTracking:
+    """Tests for negotiation history tracking."""
+
+    def test_history_records_all_turns(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        responder: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+        counter_proposal: NegotiationProposal,
+    ):
+        """Test that history records all turns."""
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+        state_machine.counter(actor=responder.agent_id, proposal=counter_proposal)
+        state_machine.accept(actor=initiator.agent_id)
+
+        history = state_machine.session.history
+        assert len(history) == 3
+
+        assert history[0].turn_number == 1
+        assert history[0].action == NegotiationAction.PROPOSE
+        assert history[0].actor == initiator.agent_id
+
+        assert history[1].turn_number == 2
+        assert history[1].action == NegotiationAction.COUNTER
+        assert history[1].actor == responder.agent_id
+
+        assert history[2].turn_number == 3
+        assert history[2].action == NegotiationAction.ACCEPT
+        assert history[2].actor == initiator.agent_id
+
+    def test_history_includes_timestamps(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test that history includes timestamps."""
+        state_machine.propose(actor=initiator.agent_id, proposal=sample_proposal)
+
+        turn = state_machine.session.history[0]
+        assert turn.timestamp is not None
+        assert "T" in turn.timestamp  # ISO format
+        assert turn.timestamp.endswith("Z")
+
+    def test_history_includes_metadata(
+        self,
+        state_machine: NegotiationStateMachine,
+        initiator: AgentIdentity,
+        sample_proposal: NegotiationProposal,
+    ):
+        """Test that history can include metadata."""
+        metadata = TurnMetadata(
+            automated=False,
+            response_time_ms=150,
+            confidence=0.9,
+        )
+        state_machine.transition(
+            target=NegotiationStatus.PROPOSAL_SENT,
+            actor=initiator.agent_id,
+            action=NegotiationAction.PROPOSE,
+            proposal=sample_proposal,
+            metadata=metadata,
+        )
+
+        turn = state_machine.session.history[0]
+        assert turn.metadata is not None
+        assert turn.metadata.response_time_ms == 150
+        assert turn.metadata.confidence == 0.9
+
+
+class TestRiskAndStrategy:
+    """Tests for risk and strategy data types."""
+
+    def test_risk_factor_creation(self):
+        """Test creating a risk factor."""
+        factor = RiskFactor(
+            category="security",
+            description="Untrusted agent",
+            severity=RiskLevel.HIGH,
+            likelihood=0.7,
+        )
+        assert factor.category == "security"
+        assert factor.severity == RiskLevel.HIGH
+
+    def test_risk_assessment_creation(self):
+        """Test creating a risk assessment."""
+        assessment = RiskAssessment(
+            overall_risk=RiskLevel.MODERATE,
+            factors=[
+                RiskFactor(
+                    category="compliance",
+                    description="Missing SOC2",
+                    severity=RiskLevel.MODERATE,
+                    likelihood=0.5,
+                )
+            ],
+            mitigations=["Request compliance documentation"],
+        )
+        assert assessment.overall_risk == RiskLevel.MODERATE
+        assert len(assessment.factors) == 1
+
+    def test_negotiation_strategy_creation(self):
+        """Test creating a negotiation strategy."""
+        strategy = NegotiationStrategy(
+            approach=StrategyApproach.COLLABORATIVE,
+            priority_capabilities=["task-exec", "data-access"],
+            max_concession_percentage=0.3,
+            must_have_terms=["rate_limit >= 50"],
+            nice_to_have_terms=["priority_level >= 5"],
+            time_sensitivity=0.5,
+        )
+        assert strategy.approach == StrategyApproach.COLLABORATIVE
+        assert len(strategy.priority_capabilities) == 2
+        assert strategy.max_concession_percentage == 0.3
+
+
+class TestAgentIdentity:
+    """Tests for AgentIdentity dataclass."""
+
+    def test_minimal_identity(self):
+        """Test creating minimal identity."""
+        identity = AgentIdentity(
+            agent_id="urn:agent:test:agent:1.0.0",
+            name="Test Agent",
+            version="1.0.0",
+            description="A test agent",
+        )
+        assert identity.agent_id == "urn:agent:test:agent:1.0.0"
+        assert identity.provider is None
+        assert identity.trust_domain is None
+
+    def test_full_identity(self):
+        """Test creating full identity."""
+        identity = AgentIdentity(
+            agent_id="urn:agent:acme:planner:2.0.0",
+            name="Acme Planner Pro",
+            version="2.0.0",
+            description="Advanced planning agent",
+            provider="Acme Corp",
+            trust_domain="spiffe://acme.com/agents",
+        )
+        assert identity.provider == "Acme Corp"
+        assert identity.trust_domain == "spiffe://acme.com/agents"
+
+
+class TestIntegration:
+    """Integration tests for the complete negotiation workflow."""
+
+    def test_end_to_end_agreement(self):
+        """Test complete end-to-end negotiation reaching agreement."""
+        # Setup agents
+        initiator = AgentIdentity(
+            agent_id="urn:agent:org1:task-manager:1.0.0",
+            name="Task Manager",
+            version="1.0.0",
+            description="Manages complex tasks",
+        )
+        responder = AgentIdentity(
+            agent_id="urn:agent:org2:data-processor:1.0.0",
+            name="Data Processor",
+            version="1.0.0",
+            description="Processes large datasets",
+        )
+
+        # Create session with context
+        context = NegotiationContext(
+            purpose="Data processing delegation",
+            urgency=UrgencyLevel.HIGH,
+            tags=["data", "batch-processing"],
+        )
+        session = NegotiationSession(
+            session_id="e2e-test-001",
+            initiator=initiator,
+            responder=responder,
+            expires_in_hours=48,
+            context=context,
+        )
+        sm = NegotiationStateMachine(session)
+
+        # Track state changes
+        transitions = []
+        sm.register_callback(lambda o, n, t: transitions.append((o.value, n.value)))
+
+        # Initial proposal
+        proposal = NegotiationProposal(
+            proposal_id="p-001",
+            capability_requirements=[
+                CapabilityNegotiationItem(
+                    capability_id="data-process",
+                    capability_name="Data Processing",
+                    required=True,
+                    parameters=[
+                        NegotiationParameter(
+                            name="batch_size",
+                            requested_value="10000",
+                            min_value="1000",
+                        )
+                    ],
+                )
+            ],
+            terms=NegotiationTerms(
+                duration_hours=168,
+                rate_limit_per_minute=200,
+                billing_model="per_call",
+            ),
+            valid_until=(datetime.utcnow() + timedelta(hours=24)).isoformat() + "Z",
+        )
+        sm.propose(actor=initiator.agent_id, proposal=proposal)
+
+        # Counter-proposal
+        counter = NegotiationProposal(
+            proposal_id="p-002",
+            capability_requirements=proposal.capability_requirements,
+            terms=NegotiationTerms(
+                duration_hours=168,
+                rate_limit_per_minute=100,  # Lower rate limit
+                billing_model="per_call",
+            ),
+            valid_until=proposal.valid_until,
+        )
+        sm.counter(actor=responder.agent_id, proposal=counter)
+
+        # Accept counter
+        sm.accept(actor=initiator.agent_id, rationale="Rate limit acceptable")
+
+        # Verify final state
+        assert session.status == NegotiationStatus.ACCEPTED
+        assert session.turn_count == 3
+        assert session.result.outcome == NegotiationOutcome.AGREEMENT
+        assert len(transitions) == 3
+        assert transitions == [
+            ("initiated", "proposal_sent"),
+            ("proposal_sent", "counter_offered"),
+            ("counter_offered", "accepted"),
+        ]
+
+        # Verify serialization
+        data = session.to_dict()
+        assert data["status"] == "accepted"
+        assert data["turn_count"] == 3
+        assert data["is_terminal"] is True


### PR DESCRIPTION
## Summary

Implements **Task 3.5: Negotiation State Machine** from Phase 3 (Agent-to-Agent Interface Negotiation).

- Add BAML types for negotiation protocol in `baml_src/negotiation_protocol.baml`
- Implement `NegotiationStateMachine` class with valid state transitions enforcement
- Support proposal/counter-offer workflow with full history tracking
- Handle session expiration and state change callbacks
- Add 69 comprehensive tests covering all state transitions and edge cases

### State Transitions

```
INITIATED → PROPOSAL_SENT, CANCELLED, EXPIRED
PROPOSAL_SENT → COUNTER_OFFERED, ACCEPTED, REJECTED, EXPIRED
COUNTER_OFFERED → COUNTER_OFFERED, ACCEPTED, REJECTED, EXPIRED, ADAPTED
```

### Key Features

- **State validation**: Invalid transitions are rejected with helpful error messages
- **Turn history**: All actions are recorded with timestamps and metadata
- **Session expiration**: Automatic expiration handling with configurable timeout
- **Callbacks**: Register callbacks to react to state changes
- **Proposal tracking**: Current proposal is always available for reference

## Test plan

- [x] Run `pytest tests/test_negotiation_state.py -v` - 69 tests pass
- [x] Run `pytest` - All 1443 tests pass
- [ ] Manual verification of state machine flow

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)