### PR TITLE
feat(context): Fix BAML syntax and add context primitives documentation (#101)

### DIFF
--- a/baml_src/accessibility_analysis.baml
+++ b/baml_src/accessibility_analysis.baml
@@ -73,8 +73,8 @@ class ResponseAccessibilityAnalysis {
 
 /// Analyze a response for accessibility compliance
 function AnalyzeResponseAccessibility(
-  response string,
-  config AccessibilityAnalysisConfig
+  response: string,
+  config: AccessibilityAnalysisConfig
 ) -> ResponseAccessibilityAnalysis {
   client CustomSonnet4
   prompt #"
@@ -133,8 +133,8 @@ function AnalyzeResponseAccessibility(
 
 /// Suggest improvements to make a response more accessible
 function SuggestAccessibilityImprovements(
-  response string,
-  target_level ComplianceLevel
+  response: string,
+  target_level: ComplianceLevel
 ) -> AccessibilityImprovementSuggestions {
   client CustomSonnet4
   prompt #"
@@ -181,9 +181,9 @@ class TextImprovement {
 
 /// Rewrite a response to meet accessibility requirements
 function RewriteForAccessibility(
-  response string,
-  target_level ComplianceLevel,
-  preserve_meaning bool
+  response: string,
+  target_level: ComplianceLevel,
+  preserve_meaning: bool
 ) -> AccessibleRewrite {
   client CustomSonnet4
   prompt #"
@@ -197,7 +197,7 @@ function RewriteForAccessibility(
     - Reading grade ≤ 12
     - Sentence length ≤ 35 words
     - Define technical terms
-    {% elsif target_level == "LEVEL_AA" %}
+    {% elif target_level == "LEVEL_AA" %}
     - Reading grade ≤ 8
     - Sentence length ≤ 25 words
     - Use common vocabulary
@@ -286,8 +286,8 @@ class LUIAccessibilityEvaluation {
 
 /// Evaluate a complete LUI schema for accessibility compliance
 function EvaluateLUIAccessibility(
-  schema InterfaceSchema,
-  target_level ComplianceLevel
+  schema: InterfaceSchema,
+  target_level: ComplianceLevel
 ) -> LUIAccessibilityEvaluation {
   client CustomSonnet4
   prompt #"
@@ -391,8 +391,8 @@ class SimplificationResult {
 
 /// Detect jargon in text and suggest alternatives
 function DetectJargon(
-  text string,
-  include_definitions bool
+  text: string,
+  include_definitions: bool
 ) -> JargonDetectionResult {
   client CustomSonnet4
   prompt #"
@@ -430,9 +430,9 @@ function DetectJargon(
 
 /// Simplify text by replacing jargon with plain language
 function SimplifyResponse(
-  text string,
-  preserve_technical_accuracy bool,
-  target_reading_level int
+  text: string,
+  preserve_technical_accuracy: bool,
+  target_reading_level: int
 ) -> SimplificationResult {
   client CustomSonnet4
   prompt #"

--- a/baml_src/accessibility_report.baml
+++ b/baml_src/accessibility_report.baml
@@ -8,7 +8,7 @@
 // ============================================
 
 /// Executive summary of accessibility report
-class AccessibilitySummary {
+class ReportAccessibilitySummary {
   total_components int @description("Total number of components evaluated")
   passing_components int @description("Components meeting target level")
   critical_violations int @description("Count of critical violations")
@@ -87,7 +87,7 @@ class ReportViolation {
 // ============================================
 
 /// Complete accessibility compliance report
-class AccessibilityReport {
+class DetailedAccessibilityReport {
   schema_name string @description("Name of the evaluated schema")
   target_level string @description("Target compliance level (A, AA, AAA)")
   achieved_level string? @description("Actually achieved level")
@@ -95,7 +95,7 @@ class AccessibilityReport {
   score_percentage int @description("Score as percentage")
   passes bool @description("Whether target level was achieved")
   generated_at string @description("ISO timestamp of report generation")
-  summary AccessibilitySummary @description("Executive summary")
+  summary ReportAccessibilitySummary @description("Executive summary")
   component_details ComponentAccessibilityReport[] @description("Per-component details")
   disability_coverage DisabilityAccessibilityReport[] @description("Per-disability coverage")
   violations ReportViolation[] @description("All violations found")
@@ -122,10 +122,10 @@ class ReportGenerationInput {
 
 /// Generate executive summary from violations
 function GenerateAccessibilitySummary(
-  violations ReportViolation[],
-  component_count int,
-  passing_count int
-) -> AccessibilitySummary {
+  violations: ReportViolation[],
+  component_count: int,
+  passing_count: int
+) -> ReportAccessibilitySummary {
   client CustomSonnet4
   prompt #"
     Generate an executive summary of accessibility findings.
@@ -148,8 +148,8 @@ function GenerateAccessibilitySummary(
 
 /// Generate prioritized recommendations
 function GenerateRecommendations(
-  violations ReportViolation[],
-  disability_reports DisabilityAccessibilityReport[]
+  violations: ReportViolation[],
+  disability_reports: DisabilityAccessibilityReport[]
 ) -> AccessibilityRecommendation[] {
   client CustomSonnet4
   prompt #"
@@ -178,9 +178,9 @@ function GenerateRecommendations(
 
 /// Analyze schema for accessibility and generate full report
 function AnalyzeAccessibility(
-  schema_json string,
-  target_level string
-) -> AccessibilityReport {
+  schema_json: string,
+  target_level: string
+) -> DetailedAccessibilityReport {
   client CustomSonnet4
   prompt #"
     Analyze the schema for accessibility compliance.

--- a/baml_src/accessibility_validation.baml
+++ b/baml_src/accessibility_validation.baml
@@ -98,7 +98,7 @@ class AccessibilityProfile {
 // ============================================
 
 /// Severity of accessibility violations
-enum ViolationSeverity {
+enum ValidationViolationSeverity {
   CRITICAL @description("Prevents access for some users - must fix")
   SERIOUS @description("Significant barrier - should fix for compliance")
   MODERATE @description("Some users affected - recommended to fix")
@@ -119,11 +119,11 @@ enum ImpactedGroup {
 }
 
 /// An individual accessibility violation
-class AccessibilityViolation {
+class ValidationAccessibilityViolation {
   rule_id string @description("WCAG rule identifier (e.g., WCAG-1.1.1)")
   criterion WCAGCriterion @description("Specific WCAG success criterion")
   category WCAGCategory @description("WCAG category")
-  severity ViolationSeverity @description("Severity of the violation")
+  severity ValidationViolationSeverity @description("Severity of the violation")
   element string @description("Element or component with violation")
   element_type string? @description("Type of element (image, button, etc.)")
   description string @description("Description of the violation")
@@ -180,7 +180,7 @@ class AccessibilityReport {
   wcag_level WCAGLevel @description("Target conformance level")
   achieved_level WCAGLevel? @description("Actual achieved level")
   score float @description("Accessibility score 0-100")
-  violations AccessibilityViolation[] @description("List of violations found")
+  violations ValidationAccessibilityViolation[] @description("List of violations found")
   remediations RemediationAction[]? @description("Suggested fixes")
   summary ReportSummary @description("Summary of findings")
   category_scores CategoryScores @description("Scores by WCAG category")
@@ -217,7 +217,7 @@ class ElementValidation {
   element_id string @description("Element identifier")
   element_type string @description("Type of element")
   passed_checks string[] @description("Checks that passed")
-  failed_checks AccessibilityViolation[] @description("Checks that failed")
+  failed_checks ValidationAccessibilityViolation[] @description("Checks that failed")
   suggestions string[]? @description("Improvement suggestions")
 }
 
@@ -424,7 +424,7 @@ function ValidateAccessibilityDetailed(
 }
 
 /// Detailed accessibility report with element validation
-class DetailedAccessibilityReport {
+class ValidationDetailedAccessibilityReport {
   base_report AccessibilityReport @description("Base accessibility report")
   visual_validations VisualElementValidation[]? @description("Visual element validations")
   voice_validations VoiceElementValidation[]? @description("Voice element validations")
@@ -482,7 +482,7 @@ class UserAccessibilityCheck {
 
 /// Generate remediation plan for violations
 function GenerateRemediationPlan(
-  violations: AccessibilityViolation[],
+  violations: ValidationAccessibilityViolation[],
   priority_focus: WCAGCategory?
 ) -> RemediationPlan {
   client "anthropic/claude-sonnet-4-20250514"

--- a/baml_src/agent_capability.baml
+++ b/baml_src/agent_capability.baml
@@ -30,7 +30,7 @@ class AgentCapability {
   input_schema SchemaDefinition @description("Schema for capability input")
   output_schema SchemaDefinition @description("Schema for capability output")
   constraints CapabilityConstraint[] @description("Constraints on capability usage")
-  performance_hints PerformanceHints? @description("Expected performance characteristics")
+  performance_hints CapabilityPerformanceHints? @description("Expected performance characteristics")
   trust_requirements TrustRequirements? @description("Trust requirements for this capability")
   examples CapabilityExample[]? @description("Usage examples")
   deprecated bool @description("Whether this capability is deprecated")
@@ -138,7 +138,7 @@ enum ConstraintEnforcement {
 // ============================================
 
 /// Performance characteristics of a capability
-class PerformanceHints {
+class CapabilityPerformanceHints {
   typical_latency_ms int @description("Typical response time in milliseconds")
   max_latency_ms int @description("Maximum expected response time")
   throughput_rps float @description("Expected requests per second capacity")

--- a/baml_src/agent_card.baml
+++ b/baml_src/agent_card.baml
@@ -24,7 +24,7 @@ enum ProtocolType {
 
 /// Protocol version declaration
 class SupportedProtocol {
-  protocol ProtocolType @description("Protocol type")
+  comm_protocol ProtocolType @description("Protocol type")
   version string @description("Protocol version (semver)")
   uri string? @description("Protocol specification URI")
   extensions string[]? @description("Supported protocol extensions")
@@ -72,7 +72,7 @@ class AuthConfig {
 class CardEndpoint {
   endpoint_type EndpointType @description("Type of endpoint")
   url string @description("Endpoint URL")
-  protocol ProtocolType @description("Communication protocol")
+  comm_protocol ProtocolType @description("Communication protocol")
   auth_config AuthConfig? @description("Authentication configuration")
   timeout_ms int? @description("Request timeout in milliseconds")
   retry_policy RetryPolicy? @description("Retry policy for this endpoint")
@@ -207,7 +207,7 @@ class AgentCardError {
 class ProtocolNegotiationRequest {
   request_id string @description("Unique request identifier")
   client_protocols SupportedProtocol[] @description("Protocols supported by client")
-  preferred_protocol ProtocolType? @description("Client's preferred protocol")
+  preferred_comm_protocol ProtocolType? @description("Client's preferred protocol")
   capabilities_required string[]? @description("Capability IDs that must be supported")
 }
 

--- a/baml_src/agent_identity.baml
+++ b/baml_src/agent_identity.baml
@@ -68,7 +68,7 @@ class AgentRegistration {
 /// An endpoint where an agent can be reached
 class AgentEndpoint {
   endpoint_id string @description("Unique identifier for this endpoint")
-  protocol EndpointProtocol @description("Communication protocol")
+  comm_protocol EndpointProtocol @description("Communication protocol")
   url string @description("Endpoint URL")
   priority int @description("Priority for endpoint selection (lower = preferred)")
   health_check_path string? @description("Path for health check requests")

--- a/baml_src/aria_live_regions.baml
+++ b/baml_src/aria_live_regions.baml
@@ -46,8 +46,8 @@ enum ScreenReader {
   ORCA @description("Linux")
 }
 
-/// Types of content for automatic configuration
-enum ContentType {
+/// Types of content for automatic ARIA configuration
+enum ARIAContentType {
   MESSAGE @description("Standard message/response")
   ERROR @description("Error message")
   WARNING @description("Warning message")
@@ -90,7 +90,7 @@ class LiveRegionInput {
   content string @description("Content to wrap in live region")
   politeness ARIAPoliteness @description("Politeness level")
   role ARIARole? @description("Optional specific role")
-  content_type ContentType? @description("Type of content for auto-config")
+  content_type ARIAContentType? @description("Type of content for auto-config")
   sender string? @description("Who sent the message (for chat)")
   aria_label string? @description("Custom accessible label")
 }
@@ -146,7 +146,7 @@ class ScreenReaderCompatibility {
 
 /// Generate ARIA live region for content
 function GenerateLiveRegion(
-  input LiveRegionInput
+  input: LiveRegionInput
 ) -> LiveRegionResult {
   client CustomSonnet4
   prompt #"
@@ -186,8 +186,8 @@ function GenerateLiveRegion(
 
 /// Analyze content and recommend ARIA configuration
 function RecommendARIAConfig(
-  content string,
-  context string
+  content: string,
+  context: string
 ) -> ARIAConfig {
   client CustomSonnet4
   prompt #"
@@ -214,7 +214,7 @@ function RecommendARIAConfig(
 
 /// Validate ARIA live region markup
 function ValidateARIAMarkup(
-  html string
+  html: string
 ) -> LiveRegionResult {
   client CustomSonnet4
   prompt #"

--- a/baml_src/composition_execution.baml
+++ b/baml_src/composition_execution.baml
@@ -240,7 +240,7 @@ class ExecuteCompositionRequest {
   plan_id string @description("ID of the plan to execute")
   inputs ExecutionInputs @description("Inputs for the execution")
   config OrchestrationConfig @description("Orchestration configuration")
-  context ExecutionContext? @description("Execution context")
+  context CompositionExecutionContext? @description("Execution context")
 }
 
 /// Inputs for composition execution
@@ -264,8 +264,8 @@ class SecretReference {
   key string @description("Key within the source")
 }
 
-/// Context for execution
-class ExecutionContext {
+/// Context for composition execution
+class CompositionExecutionContext {
   session_id string? @description("Session identifier")
   user_id string? @description("User identifier")
   trace_id string? @description("Distributed trace ID")
@@ -334,9 +334,9 @@ class CircuitBreakerStatus {
 
 /// Execute a composition plan
 function ExecuteComposition(
-  plan string,
-  inputs string,
-  config string
+  plan: string,
+  inputs: string,
+  config: string
 ) -> CompositionExecution {
   client CustomSonnet4
   prompt #"
@@ -364,9 +364,9 @@ function ExecuteComposition(
 
 /// Generate a recovery plan for a failed execution
 function RecoverFromFailure(
-  execution string,
-  error string,
-  available_agents string
+  execution: string,
+  error: string,
+  available_agents: string
 ) -> RecoveryPlan {
   client CustomSonnet4
   prompt #"
@@ -394,8 +394,8 @@ function RecoverFromFailure(
 
 /// Determine optimal execution order considering parallelism
 function PlanExecutionOrder(
-  plan string,
-  config string
+  plan: string,
+  config: string
 ) -> ExecutionOrder {
   client CustomSonnet4
   prompt #"

--- a/baml_src/composition_planning.baml
+++ b/baml_src/composition_planning.baml
@@ -348,9 +348,9 @@ class ValidationWarning {
 
 /// Plan a composition to achieve a goal
 function PlanComposition(
-  goal string,
-  available_agents string,
-  constraints string?
+  goal: string,
+  available_agents: string,
+  constraints: string?
 ) -> CompositionPlan {
   client CustomSonnet4
   prompt #"
@@ -387,8 +387,8 @@ function PlanComposition(
 
 /// Optimize an existing composition plan
 function OptimizePlan(
-  plan string,
-  optimization_goals string
+  plan: string,
+  optimization_goals: string
 ) -> CompositionPlan {
   client CustomSonnet4
   prompt #"
@@ -418,7 +418,7 @@ function OptimizePlan(
 
 /// Validate a composition plan
 function ValidatePlan(
-  plan string
+  plan: string
 ) -> PlanValidation {
   client CustomSonnet4
   prompt #"
@@ -441,7 +441,7 @@ function ValidatePlan(
 
 /// Analyze failure modes in a plan
 function AnalyzeFailureModes(
-  plan string
+  plan: string
 ) -> RiskAssessmentForComposition {
   client CustomSonnet4
   prompt #"

--- a/baml_src/conflict_detection.baml
+++ b/baml_src/conflict_detection.baml
@@ -108,13 +108,13 @@ class ResolutionStep {
 
 /// Effort estimate for resolution
 class EffortEstimate {
-  level EffortLevel @description("Overall effort level")
+  level ConflictEffortLevel @description("Overall effort level")
   estimated_hours float? @description("Estimated hours if quantifiable")
   complexity_factors string[] @description("Factors contributing to complexity")
 }
 
 /// Effort levels for resolution
-enum EffortLevel {
+enum ConflictEffortLevel {
   TRIVIAL @description("Automatic or near-instant")
   LOW @description("Minutes of work")
   MEDIUM @description("Hours of work")
@@ -238,9 +238,9 @@ class ConflictDetectionResponse {
 
 /// Analyze conflicts between two schemas and generate resolution suggestions
 function AnalyzeSchemaConflicts(
-  source_schema string,
-  target_schema string,
-  context string?
+  source_schema: string,
+  target_schema: string,
+  context: string?
 ) -> ConflictAnalysis {
   client CustomSonnet4
   prompt #"
@@ -271,9 +271,9 @@ function AnalyzeSchemaConflicts(
 
 /// Suggest the optimal resolution strategy for a set of conflicts
 function SuggestResolutionStrategy(
-  conflicts Conflict[],
-  available_strategies ResolutionStrategy[],
-  constraints string[]?
+  conflicts: Conflict[],
+  available_strategies: ResolutionStrategy[],
+  constraints: string[]?
 ) -> ResolutionPath[] {
   client CustomSonnet4
   prompt #"
@@ -302,9 +302,9 @@ function SuggestResolutionStrategy(
 
 /// Validate whether a proposed resolution will work
 function ValidateResolution(
-  conflict Conflict,
-  proposed_resolution ResolutionPath,
-  current_state string
+  conflict: Conflict,
+  proposed_resolution: ResolutionPath,
+  current_state: string
 ) -> ResolutionValidation {
   client CustomSonnet4
   prompt #"

--- a/baml_src/conflict_mediation.baml
+++ b/baml_src/conflict_mediation.baml
@@ -20,7 +20,7 @@ enum MediationStyle {
 }
 
 /// Strategy for resolving deadlocks
-enum ResolutionStrategy {
+enum MediationResolutionStrategy {
   TRANSFORM @description("Convert data format to achieve compatibility")
   SUBSET @description("Use common subset of capabilities that both support")
   MEDIATE @description("Third-party mediation to find compromise")
@@ -134,7 +134,7 @@ class ConflictSummaryForMediation {
 /// Entry in conflict history
 class ConflictHistoryEntry {
   timestamp string @description("When this attempt occurred")
-  strategy_tried ResolutionStrategy @description("Strategy that was attempted")
+  strategy_tried MediationResolutionStrategy @description("Strategy that was attempted")
   outcome string @description("What happened")
   notes string? @description("Additional notes")
 }
@@ -231,7 +231,7 @@ class DeadlockResolutionRequest {
   deadlock_turns int @description("Number of turns in deadlock")
   turn_history TurnSummary[] @description("Recent turn summaries")
   party_positions PartyPosition[] @description("Current positions of all parties")
-  previously_tried ResolutionStrategy[] @description("Strategies already attempted")
+  previously_tried MediationResolutionStrategy[] @description("Strategies already attempted")
 }
 
 /// Summary of a negotiation turn
@@ -248,7 +248,7 @@ class DeadlockResolution {
   resolution_id string @description("Unique resolution identifier")
   request_id string @description("Original request ID")
   resolution_possible bool @description("Whether resolution is possible")
-  strategy ResolutionStrategy @description("Recommended strategy")
+  strategy MediationResolutionStrategy @description("Recommended strategy")
   proposal CompromiseProposal? @description("Proposed resolution if any")
   explanation string @description("Explanation of the recommendation")
   escalation_needed bool @description("Whether escalation is needed")
@@ -259,7 +259,7 @@ class DeadlockResolution {
 
 /// An alternative strategy option
 class AlternativeStrategy {
-  strategy ResolutionStrategy @description("The strategy")
+  strategy MediationResolutionStrategy @description("The strategy")
   description string @description("How to apply it")
   pros string[] @description("Advantages")
   cons string[] @description("Disadvantages")
@@ -298,7 +298,7 @@ class EscalationResponse {
 
 /// Mediate a conflict between two parties
 function MediateConflict(
-  request MediationRequest
+  request: MediationRequest
 ) -> MediationResult {
   client CustomSonnet4
   prompt #"
@@ -327,7 +327,7 @@ function MediateConflict(
 
 /// Resolve a deadlock in negotiation
 function ResolveDeadlock(
-  request DeadlockResolutionRequest
+  request: DeadlockResolutionRequest
 ) -> DeadlockResolution {
   client CustomSonnet4
   prompt #"
@@ -353,8 +353,8 @@ function ResolveDeadlock(
 
 /// Find common ground between party positions
 function FindCommonGround(
-  party_a PartyPosition,
-  party_b PartyPosition
+  party_a: PartyPosition,
+  party_b: PartyPosition
 ) -> CommonGroundAnalysis {
   client CustomSonnet4
   prompt #"
@@ -422,9 +422,9 @@ class IncompatibleTerm {
 
 /// Generate creative solutions for a conflict
 function GenerateCreativeSolutions(
-  conflict ConflictSummaryForMediation,
-  constraints string[],
-  preferences string[]
+  conflict: ConflictSummaryForMediation,
+  constraints: string[],
+  preferences: string[]
 ) -> CreativeSolution[] {
   client CustomSonnet4
   prompt #"

--- a/baml_src/context_primitives.baml
+++ b/baml_src/context_primitives.baml
@@ -314,7 +314,7 @@ function SummarizeConversation(
   existing_summary: string?,
   max_length: int?
 ) -> ConversationSummary {
-  client GPT4
+  client CustomSonnet4
   prompt #"
     You are a conversation summarization expert. Your task is to create a concise,
     informative summary that preserves the essential context for future conversation turns.
@@ -364,7 +364,7 @@ function ScoreTurnImportance(
   current_context: string?,
   important_entities: string[]?
 ) -> TurnImportance[] {
-  client GPT4
+  client CustomSonnet4
   prompt #"
     You are evaluating conversation turns for importance to determine which should
     be retained in a limited context window.

--- a/baml_src/contract_net.baml
+++ b/baml_src/contract_net.baml
@@ -353,13 +353,13 @@ class TaskProgressReport {
   reported_at string @description("ISO 8601 timestamp")
   progress_percentage float @description("Completion percentage (0.0-100.0)")
   current_step int @description("Current step number")
-  status ExecutionStatus @description("Current execution status")
+  status ContractExecutionStatus @description("Current execution status")
   issues ExecutionIssue[]? @description("Any issues encountered")
   estimated_remaining_ms int? @description("Estimated time remaining")
 }
 
 /// Status of task execution
-enum ExecutionStatus {
+enum ContractExecutionStatus {
   NOT_STARTED @description("Execution has not begun")
   IN_PROGRESS @description("Execution is ongoing")
   PAUSED @description("Execution is paused")
@@ -371,14 +371,14 @@ enum ExecutionStatus {
 /// Issue encountered during execution
 class ExecutionIssue {
   issue_id string @description("Unique identifier for this issue")
-  severity IssueSeverity @description("Severity of the issue")
+  severity ContractIssueSeverity @description("Severity of the issue")
   description string @description("Description of the issue")
   impact string @description("Impact on task completion")
   resolution string? @description("Resolution if resolved")
 }
 
 /// Severity of an execution issue
-enum IssueSeverity {
+enum ContractIssueSeverity {
   INFO @description("Informational, no impact")
   WARNING @description("Minor issue, task can continue")
   ERROR @description("Significant issue, may impact completion")
@@ -390,16 +390,16 @@ class TaskExecutionResult {
   result_id string @description("Unique identifier for this result")
   contract_id string @description("ID of the contract")
   completed_at string @description("ISO 8601 completion timestamp")
-  status ExecutionStatus @description("Final status")
+  status ContractExecutionStatus @description("Final status")
   output string? @description("Task output as JSON string")
   actual_cost CostEstimate? @description("Actual cost incurred")
   actual_latency_ms int @description("Actual execution time")
-  quality_metrics QualityMetrics? @description("Quality measurements")
+  quality_metrics ContractQualityMetrics? @description("Quality measurements")
   summary string @description("Human-readable summary of results")
 }
 
 /// Quality metrics for task execution
-class QualityMetrics {
+class ContractQualityMetrics {
   accuracy float? @description("Accuracy score (0.0-1.0)")
   completeness float? @description("Completeness score (0.0-1.0)")
   consistency float? @description("Consistency score (0.0-1.0)")
@@ -445,11 +445,11 @@ enum ContractNetStatus {
 
 /// Issue a Call for Proposals
 function IssueCallForProposals(
-  issuer AgentIdentity,
-  task TaskSpecification,
-  target_agents string[]?,
-  deadline_seconds int,
-  selection_criteria SelectionCriteria[]
+  issuer: AgentIdentity,
+  task: TaskSpecification,
+  target_agents: string[]?,
+  deadline_seconds: int,
+  selection_criteria: SelectionCriteria[]
 ) -> CallForProposals {
   client CustomSonnet4
   prompt #"
@@ -473,9 +473,9 @@ function IssueCallForProposals(
 
 /// Evaluate all bids for a CFP
 function EvaluateBids(
-  cfp CallForProposals,
-  proposals ContractProposal[],
-  refusals BidRefusal[]?
+  cfp: CallForProposals,
+  proposals: ContractProposal[],
+  refusals: BidRefusal[]?
 ) -> BidEvaluation {
   client CustomSonnet4
   prompt #"
@@ -502,10 +502,10 @@ function EvaluateBids(
 
 /// Generate a contract proposal for a CFP
 function GenerateContractProposal(
-  cfp CallForProposals,
-  proposer AgentIdentity,
-  available_capabilities AgentCapability[],
-  cost_constraints CostEstimate?
+  cfp: CallForProposals,
+  proposer: AgentIdentity,
+  available_capabilities: AgentCapability[],
+  cost_constraints: CostEstimate?
 ) -> ContractProposal {
   client CustomSonnet4
   prompt #"
@@ -529,11 +529,11 @@ function GenerateContractProposal(
 
 /// Decide whether to submit a bid or refuse
 function DecideToBid(
-  cfp CallForProposals,
-  agent_identity AgentIdentity,
-  available_capabilities AgentCapability[],
-  current_workload float,
-  policy_constraints string[]?
+  cfp: CallForProposals,
+  agent_identity: AgentIdentity,
+  available_capabilities: AgentCapability[],
+  current_workload: float,
+  policy_constraints: string[]?
 ) -> BidDecision {
   client CustomSonnet4
   prompt #"

--- a/baml_src/conversational_testing.baml
+++ b/baml_src/conversational_testing.baml
@@ -58,7 +58,7 @@ class TestTurn {
   expected_intent string? @description("Expected detected intent")
   expected_entities ExpectedEntity[] @description("Expected entity extractions")
   assertions ConversationAssertion[] @description("Assertions for this turn")
-  context_requirements ContextRequirement[] @description("Context that should be available")
+  context_requirements TestContextRequirement[] @description("Context that should be available")
   delay_ms int? @description("Optional delay before this turn")
   metadata map<string, string>? @description("Additional turn metadata")
 }
@@ -80,7 +80,7 @@ class ExpectedEntity {
 }
 
 /// Context requirement for a turn
-class ContextRequirement {
+class TestContextRequirement {
   key string @description("Context key that should exist")
   value_match string? @description("Expected value or pattern")
   match_type MatchType @description("Type of value matching")
@@ -227,14 +227,14 @@ class InitialEntity {
 /// Simulated user profile for testing
 class TestUserProfile {
   user_id string @description("Test user identifier")
-  expertise_level ExpertiseLevel @description("User's expertise level")
+  expertise_level TestExpertiseLevel @description("User's expertise level")
   preferences map<string, string>? @description("User preferences")
   history_summary string? @description("Summary of user history")
   accessibility_needs string[] @description("Accessibility requirements")
 }
 
 /// User expertise level
-enum ExpertiseLevel {
+enum TestExpertiseLevel {
   NOVICE @description("New user, needs guidance")
   INTERMEDIATE @description("Familiar with basics")
   ADVANCED @description("Experienced user")
@@ -317,13 +317,13 @@ class TurnResult {
   input string @description("The input text")
   actual_response string? @description("The actual response")
   detected_intent string? @description("The detected intent")
-  extracted_entities ExtractedEntity[] @description("Entities that were extracted")
+  extracted_entities TestExtractedEntity[] @description("Entities that were extracted")
   latency_ms int @description("Turn latency")
   passed bool @description("Whether turn assertions passed")
 }
 
 /// Entity that was extracted during test
-class ExtractedEntity {
+class TestExtractedEntity {
   entity_type string @description("Entity type")
   value string @description("Extracted value")
   confidence float @description("Extraction confidence")
@@ -376,14 +376,14 @@ class TestSuite {
   tests ConversationTest[] @description("Tests in this suite")
   default_setup TestSetup? @description("Default setup for all tests")
   default_thresholds QualityThresholds? @description("Default thresholds")
-  execution_order ExecutionOrder @description("How to order test execution")
+  execution_order TestExecutionOrder @description("How to order test execution")
   stop_on_failure bool @description("Whether to stop on first failure")
   parallel_execution bool @description("Whether tests can run in parallel")
   tags string[] @description("Suite tags")
 }
 
 /// Test execution order
-enum ExecutionOrder {
+enum TestExecutionOrder {
   SEQUENTIAL @description("Run in definition order")
   PRIORITY @description("Run by priority (critical first)")
   RANDOM @description("Random order for independence testing")

--- a/baml_src/disability_evaluation.baml
+++ b/baml_src/disability_evaluation.baml
@@ -91,8 +91,8 @@ class CombinedDisabilityEvaluation {
 
 /// Evaluate a schema for a specific disability type
 function EvaluateForDisability(
-  schema InterfaceSchema,
-  disability_type DisabilityType
+  schema: InterfaceSchema,
+  disability_type: DisabilityType
 ) -> DisabilityEvaluation {
   client CustomSonnet4
   prompt #"
@@ -110,14 +110,14 @@ function EvaluateForDisability(
     - No visual-only information: Is all visual content described?
     - High contrast: Is high contrast mode supported?
     - Key metric: 100% audio confirmation for all actions
-    {% elsif disability_type == "HEARING" %}
+    {% elif disability_type == "HEARING" %}
     HEARING IMPAIRMENT CRITERIA:
     - Text alternatives: Is text available for all audio content?
     - Visual alerts: Are there visual alternatives to audio alerts?
     - Captions: Is real-time captioning supported?
     - Sign language: Is sign language interpretation available?
     - Key metric: 99% caption accuracy
-    {% elsif disability_type == "MOTOR" %}
+    {% elif disability_type == "MOTOR" %}
     MOTOR IMPAIRMENT CRITERIA:
     - Extended timeout: Is timeout ≥5× standard (≥100 seconds)?
     - Single-action: Can all actions be completed with single gestures?
@@ -125,13 +125,13 @@ function EvaluateForDisability(
     - Voice input: Is voice input supported as alternative?
     - Switch access: Is switch device access supported?
     - Key metric: ≥5× timeout duration
-    {% elsif disability_type == "SPEECH" %}
+    {% elif disability_type == "SPEECH" %}
     SPEECH IMPAIRMENT CRITERIA:
     - Text input: Is there 100% text fallback for voice?
     - AAC devices: Is AAC device input supported?
     - Gesture input: Are gesture alternatives available?
     - Key metric: 100% text fallback coverage
-    {% elsif disability_type == "COGNITIVE" %}
+    {% elif disability_type == "COGNITIVE" %}
     COGNITIVE IMPAIRMENT CRITERIA:
     - Reading level: Is content at Grade 6-8 level?
     - Consistent navigation: Are patterns predictable?
@@ -139,7 +139,7 @@ function EvaluateForDisability(
     - Undo support: Can actions be reversed?
     - Auto-save: Is work automatically saved?
     - Key metric: Grade 6-8 reading level
-    {% elsif disability_type == "NEUROLOGICAL" %}
+    {% elif disability_type == "NEUROLOGICAL" %}
     NEUROLOGICAL CRITERIA:
     - Seizure safety: Are there no flashes >3Hz?
     - Animation controls: Can animations be paused/stopped?
@@ -173,7 +173,7 @@ function EvaluateForDisability(
 
 /// Evaluate a schema for all disability types
 function EvaluateAllDisabilities(
-  schema InterfaceSchema
+  schema: InterfaceSchema
 ) -> CombinedDisabilityEvaluation {
   client CustomSonnet4
   prompt #"

--- a/baml_src/entity_definitions.baml
+++ b/baml_src/entity_definitions.baml
@@ -54,12 +54,12 @@ enum AttributeType {
 
 /// Constraints on attribute values
 class AttributeConstraint {
-  constraint_type ConstraintType
+  constraint_type EntityConstraintType
   value string
   error_message string
 }
 
-enum ConstraintType {
+enum EntityConstraintType {
   MIN_LENGTH
   MAX_LENGTH
   MIN_VALUE

--- a/baml_src/intent_extraction.baml
+++ b/baml_src/intent_extraction.baml
@@ -105,10 +105,10 @@ enum ExecutionStrategy {
 class IntentDependency {
   dependent_intent_index int @description("Index of the dependent intent")
   depends_on_index int @description("Index of the intent it depends on")
-  dependency_type DependencyType
+  dependency_type IntentDependencyType
 }
 
-enum DependencyType {
+enum IntentDependencyType {
   REQUIRES_COMPLETION @description("Must complete before dependent can start")
   REQUIRES_SUCCESS @description("Must succeed for dependent to execute")
   SHARES_PARAMETER @description("Output of one is input to another")

--- a/baml_src/interaction_timing.baml
+++ b/baml_src/interaction_timing.baml
@@ -39,7 +39,7 @@ class InputMethodConfig {
 // ============================================
 
 /// Configuration for user feedback mechanisms
-class FeedbackConfig {
+class TimingFeedbackConfig {
   immediate_confirmation bool @description("Immediate feedback for user actions")
   error_messages_clear bool @description("Error messages are clear and actionable")
   success_indicators bool @description("Visual/audio success indicators")
@@ -83,7 +83,7 @@ class InteractionAccessibilityConfig {
   component_id string @description("ID of the component")
   timing TimeoutConfig @description("Timeout configuration")
   input_methods InputMethodConfig @description("Supported input methods")
-  feedback FeedbackConfig @description("Feedback mechanisms")
+  feedback TimingFeedbackConfig @description("Feedback mechanisms")
   error_handling ErrorHandlingConfig @description("Error handling configuration")
   auto_update AutoUpdateConfig? @description("Auto-update configuration if applicable")
 }
@@ -168,8 +168,8 @@ class InteractionValidationResult {
 
 /// Validate timeout configuration for a compliance level
 function ValidateTimeoutConfig(
-  config TimeoutConfig,
-  target_level ComplianceLevel
+  config: TimeoutConfig,
+  target_level: ComplianceLevel
 ) -> TimingValidationResult {
   client CustomSonnet4
   prompt #"
@@ -209,8 +209,8 @@ function ValidateTimeoutConfig(
 
 /// Validate input methods for a compliance level
 function ValidateInputMethods(
-  config InputMethodConfig,
-  target_level ComplianceLevel
+  config: InputMethodConfig,
+  target_level: ComplianceLevel
 ) -> InputValidationResult {
   client CustomSonnet4
   prompt #"
@@ -241,8 +241,8 @@ function ValidateInputMethods(
 
 /// Validate complete interaction configuration
 function ValidateInteractionConfig(
-  config InteractionAccessibilityConfig,
-  target_level ComplianceLevel
+  config: InteractionAccessibilityConfig,
+  target_level: ComplianceLevel
 ) -> InteractionValidationResult {
   client CustomSonnet4
   prompt #"

--- a/baml_src/modality_fallback.baml
+++ b/baml_src/modality_fallback.baml
@@ -94,7 +94,7 @@ class DegradedResponse {
 
 /// Transformation applied during degradation
 class DegradationTransformation {
-  transformation_type TransformationType @description("Type of transformation applied")
+  transformation_type ModalityTransformationType @description("Type of transformation applied")
   original_format string @description("Original content format")
   target_format string @description("Target content format")
   fidelity float @description("Information fidelity 0.0-1.0")
@@ -102,7 +102,7 @@ class DegradationTransformation {
 }
 
 /// Types of transformations during degradation
-enum TransformationType {
+enum ModalityTransformationType {
   VOICE_TO_TEXT @description("Voice content converted to text")
   VISUAL_TO_TEXT @description("Visual elements converted to text")
   TABLE_TO_LIST @description("Tables converted to bullet lists")
@@ -300,7 +300,7 @@ class FallbackSelection {
   rationale string @description("Why this was selected")
   confidence float @description("Confidence in selection 0.0-1.0")
   expected_fidelity float @description("Expected information fidelity")
-  transformations_needed TransformationType[] @description("Required transformations")
+  transformations_needed ModalityTransformationType[] @description("Required transformations")
   alternative Modality? @description("Second choice if first fails")
 }
 
@@ -374,7 +374,7 @@ class PreservePriority {
 /// Result of content transformation
 class TransformedContent {
   content MultiModalResponse @description("Transformed content")
-  transformations_applied TransformationType[] @description("What was done")
+  transformations_applied ModalityTransformationType[] @description("What was done")
   fidelity float @description("Information fidelity achieved 0.0-1.0")
   lost_elements string[]? @description("Elements that couldn't be preserved")
   notes string? @description("Notes about the transformation")

--- a/baml_src/negotiation_protocol.baml
+++ b/baml_src/negotiation_protocol.baml
@@ -81,21 +81,21 @@ class SLARequirement {
 
 /// Additional constraint on a proposal
 class ProposalConstraint {
-  constraint_type ConstraintType @description("Type of constraint")
+  constraint_type NegotiationConstraintType @description("Type of constraint")
   field string @description("Field the constraint applies to")
-  operator ConstraintOperator @description("Comparison operator")
+  operator NegotiationConstraintOperator @description("Comparison operator")
   value string @description("Constraint value")
 }
 
 /// Types of constraints
-enum ConstraintType {
+enum NegotiationConstraintType {
   REQUIRED @description("Must be satisfied")
   PREFERRED @description("Preferred but not required")
   PROHIBITED @description("Must not be present")
 }
 
 /// Comparison operators for constraints
-enum ConstraintOperator {
+enum NegotiationConstraintOperator {
   EQUALS @description("Exact match")
   NOT_EQUALS @description("Must not match")
   GREATER_THAN @description("Greater than value")
@@ -168,14 +168,14 @@ enum NegotiationOutcome {
 /// Context for a negotiation session
 class NegotiationContext {
   purpose string @description("Purpose of the negotiation")
-  urgency UrgencyLevel @description("Urgency level of the request")
+  urgency NegotiationUrgencyLevel @description("Urgency level of the request")
   previous_session_id string? @description("ID of related previous session")
   tags string[]? @description("Tags for categorization")
   custom_data string? @description("Custom JSON data")
 }
 
 /// Urgency level for a negotiation
-enum UrgencyLevel {
+enum NegotiationUrgencyLevel {
   LOW @description("No time pressure")
   NORMAL @description("Standard priority")
   HIGH @description("Needs quick resolution")
@@ -220,10 +220,10 @@ class StateTransitionError {
 
 /// Evaluate a proposal and suggest a response
 function EvaluateProposal(
-  session NegotiationSession,
-  our_identity AgentIdentity,
-  our_capabilities string[],
-  our_constraints ProposalConstraint[]?
+  session: NegotiationSession,
+  our_identity: AgentIdentity,
+  our_capabilities: string[],
+  our_constraints: ProposalConstraint[]?
 ) -> ProposalEvaluation {
   client CustomSonnet4
   prompt #"
@@ -261,7 +261,7 @@ class RiskAssessment {
 }
 
 /// Risk level for negotiation
-enum RiskLevel {
+enum NegotiationRiskLevel {
   LOW @description("Minimal risk")
   MODERATE @description("Some concerns but manageable")
   HIGH @description("Significant concerns")
@@ -278,10 +278,10 @@ class RiskFactor {
 
 /// Generate an optimal counter-proposal
 function GenerateCounterProposal(
-  session NegotiationSession,
-  our_identity AgentIdentity,
-  our_capabilities string[],
-  negotiation_strategy NegotiationStrategy
+  session: NegotiationSession,
+  our_identity: AgentIdentity,
+  our_capabilities: string[],
+  negotiation_strategy: NegotiationStrategy
 ) -> NegotiationProposal {
   client CustomSonnet4
   prompt #"

--- a/baml_src/proposal_evaluation.baml
+++ b/baml_src/proposal_evaluation.baml
@@ -52,7 +52,7 @@ enum CapabilityLevel {
 class OfferedParameter {
   name string @description("Parameter name")
   value string @description("Offered value")
-  fixed bool @description("Whether this value is fixed or negotiable")
+  is_fixed bool @description("Whether this value is fixed or negotiable")
   alternatives string[]? @description("Alternative values if negotiable")
 }
 
@@ -308,12 +308,12 @@ class ProposalChange {
   field string @description("Field that was changed")
   original_value string @description("Original value")
   new_value string @description("New value")
-  change_type ChangeType @description("Type of change")
+  change_type ProposalChangeType @description("Type of change")
   justification string @description("Why this change was made")
 }
 
 /// Type of proposal change
-enum ChangeType {
+enum ProposalChangeType {
   CONCESSION @description("A concession we're making")
   REQUEST @description("A new request or increased demand")
   CLARIFICATION @description("Clarification of existing terms")
@@ -328,10 +328,10 @@ enum ChangeType {
 
 /// Evaluate a proposal against policy and capabilities
 function EvaluateProposalAgainstPolicy(
-  proposal NegotiationProposal,
-  session NegotiationSession,
-  evaluator_capabilities AgentCapability[],
-  evaluation_policy EvaluationPolicy
+  proposal: NegotiationProposal,
+  session: NegotiationSession,
+  evaluator_capabilities: AgentCapability[],
+  evaluation_policy: EvaluationPolicy
 ) -> ProposalEvaluationResult {
   client CustomSonnet4
   prompt #"
@@ -369,10 +369,10 @@ function EvaluateProposalAgainstPolicy(
 
 /// Generate an optimal counter-proposal
 function GenerateOptimalCounterProposal(
-  original_proposal NegotiationProposal,
-  gap_analysis GapAnalysis,
-  our_capabilities AgentCapability[],
-  config CounterProposalConfig
+  original_proposal: NegotiationProposal,
+  gap_analysis: GapAnalysis,
+  our_capabilities: AgentCapability[],
+  config: CounterProposalConfig
 ) -> CounterProposalResult {
   client CustomSonnet4
   prompt #"
@@ -406,9 +406,9 @@ function GenerateOptimalCounterProposal(
 
 /// Score a proposal quantitatively
 function ScoreProposal(
-  proposal NegotiationProposal,
-  our_requirements CapabilityRequest[],
-  scoring_weights ScoringWeights
+  proposal: NegotiationProposal,
+  our_requirements: CapabilityRequest[],
+  scoring_weights: ScoringWeights
 ) -> ProposalScore {
   client CustomSonnet4
   prompt #"

--- a/baml_src/schema_transformation.baml
+++ b/baml_src/schema_transformation.baml
@@ -115,7 +115,7 @@ class SchemaTransformPlan {
   reversible bool @description("Whether transformation can be reversed")
   reverse_plan_id string? @description("ID of reverse transformation plan if reversible")
   estimated_complexity TransformComplexity @description("Estimated transformation complexity")
-  validation_result PlanValidation @description("Validation status of the plan")
+  validation_result SchemaPlanValidation @description("Validation status of the plan")
   metadata PlanMetadata? @description("Additional metadata")
 }
 
@@ -148,15 +148,15 @@ enum TransformComplexity {
 }
 
 /// Validation result for a transform plan
-class PlanValidation {
+class SchemaPlanValidation {
   is_valid bool @description("Whether plan is valid")
-  errors ValidationIssue[] @description("Validation errors")
-  warnings ValidationIssue[] @description("Validation warnings")
+  errors SchemaValidationIssue[] @description("Validation errors")
+  warnings SchemaValidationIssue[] @description("Validation warnings")
   coverage_analysis CoverageAnalysis @description("Field coverage analysis")
 }
 
 /// A validation issue (error or warning)
-class ValidationIssue {
+class SchemaValidationIssue {
   issue_id string @description("Issue identifier")
   severity string @description("error or warning")
   message string @description("Issue description")
@@ -305,9 +305,9 @@ class ExecuteTransformResponse {
 
 /// Generate a transformation plan between two schemas
 function GenerateTransformPlan(
-  source_schema string,
-  target_schema string,
-  preferences string?
+  source_schema: string,
+  target_schema: string,
+  preferences: string?
 ) -> SchemaTransformPlan {
   client CustomSonnet4
   prompt #"
@@ -337,9 +337,9 @@ function GenerateTransformPlan(
 
 /// Apply a transformation plan to actual data
 function ApplyTransformation(
-  input_data string,
-  plan string,
-  options string?
+  input_data: string,
+  plan: string,
+  options: string?
 ) -> TransformResult {
   client CustomSonnet4
   prompt #"
@@ -368,10 +368,10 @@ function ApplyTransformation(
 
 /// Suggest improvements to a transformation plan
 function SuggestPlanImprovements(
-  plan string,
-  sample_data string?,
-  issues string[]
-) -> PlanImprovement[] {
+  plan: string,
+  sample_data: string?,
+  issues: string[]
+) -> SchemaPlanImprovement[] {
   client CustomSonnet4
   prompt #"
     Analyze this transformation plan and suggest improvements.
@@ -398,7 +398,7 @@ function SuggestPlanImprovements(
 }
 
 /// Suggestion for improving a transform plan
-class PlanImprovement {
+class SchemaPlanImprovement {
   improvement_id string @description("Unique improvement identifier")
   target_transformation_id string? @description("ID of transformation to improve")
   improvement_type string @description("Type of improvement")

--- a/baml_src/security_context.baml
+++ b/baml_src/security_context.baml
@@ -21,7 +21,7 @@ enum CredentialType {
 }
 
 /// Level of trust established
-enum TrustLevel {
+enum SecurityTrustLevel {
   NONE @description("No trust established")
   LOW @description("Basic authentication only")
   MEDIUM @description("Authenticated with limited verification")
@@ -124,7 +124,7 @@ class CredentialMetadata {
 class CredentialValidation {
   credential_id string @description("ID of validated credential")
   status CredentialStatus @description("Validation status")
-  trust_level TrustLevel @description("Trust level achieved")
+  trust_level SecurityTrustLevel @description("Trust level achieved")
   valid_scopes string[] @description("Scopes that are valid")
   invalid_scopes string[] @description("Scopes that are invalid/expired")
   expires_at string? @description("When credential expires")
@@ -163,7 +163,7 @@ class TrustChainValidation {
   chain_length int @description("Number of entries in chain")
   root_issuer string @description("Root of trust")
   final_subject string @description("End of trust chain")
-  effective_trust_level TrustLevel @description("Trust level after chain analysis")
+  effective_trust_level SecurityTrustLevel @description("Trust level after chain analysis")
   effective_permissions string[] @description("Intersection of all permissions")
   broken_links TrustChainBreak[]? @description("Any breaks in chain")
   warnings string[] @description("Validation warnings")
@@ -219,7 +219,7 @@ class PermissionCondition {
 class SecurityValidation {
   validation_id string @description("Unique validation identifier")
   valid bool @description("Whether validation passed")
-  trust_level TrustLevel @description("Established trust level")
+  trust_level SecurityTrustLevel @description("Established trust level")
   granted_permissions string[] @description("Permissions granted")
   denied_permissions string[] @description("Permissions denied")
   required_permissions string[] @description("Permissions that were required")
@@ -270,7 +270,7 @@ class SecurityAuditEntry {
   target string? @description("Target of the action")
   action string @description("Action performed")
   result string @description("Result of action")
-  trust_level TrustLevel? @description("Trust level at time of event")
+  trust_level SecurityTrustLevel? @description("Trust level at time of event")
   details AuditDetails @description("Additional event details")
 }
 
@@ -296,7 +296,7 @@ class SecuritySession {
   created_at string @description("ISO 8601 creation timestamp")
   expires_at string @description("ISO 8601 expiration timestamp")
   last_activity string @description("ISO 8601 last activity timestamp")
-  trust_level TrustLevel @description("Session trust level")
+  trust_level SecurityTrustLevel @description("Session trust level")
   permissions string[] @description("Permissions for this session")
   session_token string @description("Session token")
   refresh_token string? @description("Token to refresh session")
@@ -342,7 +342,7 @@ class InputValidationConfig {
 }
 
 /// Result of input validation
-class InputValidationResult {
+class SecurityInputValidationResult {
   valid bool @description("Whether input is valid")
   sanitized_input string? @description("Sanitized version of input")
   blocked_patterns_found string[] @description("Blocked patterns that were found")
@@ -350,7 +350,7 @@ class InputValidationResult {
 }
 
 /// Rate limiting configuration
-class RateLimitConfig {
+class SecurityRateLimitConfig {
   requests_per_minute int @description("Maximum requests per minute")
   requests_per_hour int @description("Maximum requests per hour")
   burst_limit int @description("Maximum burst of requests")
@@ -372,8 +372,8 @@ class RateLimitStatus {
 
 /// Validate a security context against required permissions
 function ValidateSecurityContext(
-  context string,
-  required_permissions string
+  context: string,
+  required_permissions: string
 ) -> SecurityValidation {
   client CustomSonnet4
   prompt #"
@@ -397,8 +397,8 @@ function ValidateSecurityContext(
 
 /// Analyze trust chain for security issues
 function AnalyzeTrustChain(
-  trust_chain string,
-  target_permissions string
+  trust_chain: string,
+  target_permissions: string
 ) -> TrustChainValidation {
   client CustomSonnet4
   prompt #"
@@ -423,8 +423,8 @@ function AnalyzeTrustChain(
 
 /// Generate security recommendations
 function GenerateSecurityRecommendations(
-  validation_result string,
-  threat_model string
+  validation_result: string,
+  threat_model: string
 ) -> SecurityRecommendations {
   client CustomSonnet4
   prompt #"

--- a/baml_src/seizure_safety.baml
+++ b/baml_src/seizure_safety.baml
@@ -163,9 +163,9 @@ class SeizureSafetyThresholds {
 
 /// Analyze flash content for seizure safety
 function AnalyzeFlashSafety(
-  frequency_hz float,
-  area_percent float,
-  is_red bool
+  frequency_hz: float,
+  area_percent: float,
+  is_red: bool
 ) -> FlashAnalysis {
   client CustomSonnet4
   prompt #"
@@ -197,8 +197,8 @@ function AnalyzeFlashSafety(
 
 /// Analyze animation for seizure safety
 function AnalyzeAnimationSafety(
-  config AnimationConfig,
-  target_level ComplianceLevel
+  config: AnimationConfig,
+  target_level: ComplianceLevel
 ) -> AnimationSafetyResult {
   client CustomSonnet4
   prompt #"
@@ -234,8 +234,8 @@ function AnalyzeAnimationSafety(
 
 /// Validate complete content for seizure safety
 function ValidateSeizureSafety(
-  content ContentConfig,
-  target_level ComplianceLevel
+  content: ContentConfig,
+  target_level: ComplianceLevel
 ) -> SeizureSafetyResult {
   client CustomSonnet4
   prompt #"

--- a/baml_src/usability_analysis.baml
+++ b/baml_src/usability_analysis.baml
@@ -74,7 +74,7 @@ class UsabilityRecommendation {
   title string @description("Brief title of the recommendation")
   current_state string @description("Description of current behavior")
   suggested_change string @description("Proposed improvement")
-  implementation_effort EffortLevel @description("Estimated effort to implement")
+  implementation_effort UsabilityEffortLevel @description("Estimated effort to implement")
   expected_improvement string @description("Expected benefit from the change")
   related_issues string[] @description("Issue IDs this recommendation addresses")
 }
@@ -88,7 +88,7 @@ enum RecommendationPriority {
 }
 
 /// Effort level for implementing changes
-enum EffortLevel {
+enum UsabilityEffortLevel {
   TRIVIAL @description("Minutes to implement")
   LOW @description("Hours to implement")
   MEDIUM @description("Days to implement")

--- a/docs/context_primitives/USER_GUIDE.md
+++ b/docs/context_primitives/USER_GUIDE.md
@@ -1,0 +1,491 @@
+# Context Primitives User Guide
+
+This guide covers the BAML context primitives for session state management in Language User Interfaces (LUI). These types enable conversation history tracking, context variables, and multi-turn interactions with configurable storage backends.
+
+## Quick Start
+
+```python
+from src.context_primitives.provider import (
+    InMemoryContextProvider,
+    ContextConfig,
+    ConversationTurn,
+)
+from datetime import datetime, timezone
+
+# Initialize provider
+config = ContextConfig(max_history_turns=20, ttl_seconds=3600)
+provider = InMemoryContextProvider(config)
+
+# Create a session
+async def main():
+    session = await provider.create_session(
+        session_id="user_123",
+        user_id="alice",
+        metadata={"channel": "web", "locale": "en-US"}
+    )
+
+    # Add a conversation turn
+    turn = ConversationTurn(
+        turn_id=1,
+        timestamp=datetime.now(timezone.utc),
+        user_input="Create a new task",
+        assistant_response="I'll create a new task for you. What should it be called?",
+        detected_intent="create-task",
+        confidence=0.95
+    )
+    await provider.add_turn("user_123", turn)
+
+    # Set context variables
+    await provider.set_variable("user_123", "current_task_id", "task_456")
+
+    # Get complete execution context
+    context = await provider.get_execution_context("user_123")
+    print(f"Session: {context.session.session_id}")
+    print(f"Turns: {len(context.history.turns)}")
+    print(f"Variables: {context.variables.variables}")
+```
+
+## Core Types
+
+### SessionContext
+
+Tracks session lifecycle and metadata:
+
+```python
+@dataclass
+class SessionContext:
+    session_id: str                    # Unique identifier
+    user_id: Optional[str]             # User for personalization
+    created_at: datetime               # Session creation time
+    last_activity: datetime            # Last interaction time
+    metadata: dict[str, str]           # Custom metadata
+    ttl_seconds: Optional[int]         # Time-to-live
+    is_active: bool                    # Session status
+```
+
+**Usage:**
+```python
+session = SessionContext(
+    session_id="sess_abc123",
+    user_id="user_456",
+    ttl_seconds=3600,  # 1 hour
+    metadata={"source": "mobile_app"}
+)
+
+# Update activity timestamp
+session.touch()
+
+# Check expiration
+if session.is_expired():
+    print("Session expired")
+```
+
+### ConversationTurn
+
+Single turn in conversation history:
+
+```python
+@dataclass
+class ConversationTurn:
+    turn_id: int                       # Sequential turn number
+    timestamp: datetime                # When turn occurred
+    user_input: str                    # User's message
+    assistant_response: str            # System response
+    detected_intent: Optional[str]     # Extracted intent
+    extracted_entities: Optional[dict] # Extracted entities
+    confidence: Optional[float]        # Intent confidence (0-1)
+    component_id: Optional[str]        # LUI component ID
+    duration_ms: Optional[int]         # Processing time
+```
+
+**Usage:**
+```python
+from datetime import datetime, timezone
+
+turn = ConversationTurn(
+    turn_id=1,
+    timestamp=datetime.now(timezone.utc),
+    user_input="Schedule a meeting with Bob tomorrow at 3pm",
+    assistant_response="I've scheduled a meeting with Bob for tomorrow at 3:00 PM.",
+    detected_intent="schedule-meeting",
+    extracted_entities={
+        "attendee": "Bob",
+        "date": "tomorrow",
+        "time": "3pm"
+    },
+    confidence=0.92
+)
+
+# Serialize for storage
+turn_dict = turn.to_dict()
+
+# Deserialize
+restored = ConversationTurn.from_dict(turn_dict)
+```
+
+### ConversationHistory
+
+Windowed history with summarization support:
+
+```python
+@dataclass
+class ConversationHistory:
+    session_id: str                    # Associated session
+    turns: list[ConversationTurn]      # Recent turns (windowed)
+    max_turns: int = 20                # Window size
+    total_turns: int                   # Total including summarized
+    summary: Optional[str]             # Summary of older turns
+    summary_updated_at: Optional[datetime]
+    token_count: Optional[int]         # Estimated tokens
+```
+
+**Usage:**
+```python
+history = ConversationHistory(session_id="sess_123", max_turns=10)
+
+# Add turns (automatic windowing)
+for i in range(15):
+    turn = ConversationTurn(
+        turn_id=i+1,
+        timestamp=datetime.now(timezone.utc),
+        user_input=f"Question {i+1}",
+        assistant_response=f"Answer {i+1}"
+    )
+    history.add_turn(turn)
+
+# Only last 10 turns retained
+assert len(history.turns) == 10
+assert history.total_turns == 15
+
+# Get recent turns
+recent = history.get_recent(5)  # Last 5 turns
+```
+
+### ContextValue
+
+Type-safe variable values:
+
+```python
+@dataclass
+class ContextValue:
+    value_type: ContextValueType       # STRING, NUMBER, BOOLEAN, etc.
+    string_value: Optional[str]
+    number_value: Optional[float]
+    boolean_value: Optional[bool]
+    list_value: Optional[list[str]]
+    object_value: Optional[dict]
+```
+
+**Usage:**
+```python
+# Create from Python values
+str_val = ContextValue.from_value("hello")        # STRING
+num_val = ContextValue.from_value(42)             # NUMBER
+bool_val = ContextValue.from_value(True)          # BOOLEAN
+list_val = ContextValue.from_value(["a", "b"])    # LIST
+obj_val = ContextValue.from_value({"key": "val"}) # OBJECT
+null_val = ContextValue.from_value(None)          # NULL
+
+# Convert back to Python
+assert str_val.to_value() == "hello"
+assert num_val.to_value() == 42.0
+```
+
+### ContextVariables
+
+Session-scoped persistent variables:
+
+```python
+@dataclass
+class ContextVariables:
+    session_id: str
+    variables: dict[str, ContextValue]
+    updated_at: datetime
+```
+
+**Usage:**
+```python
+variables = ContextVariables(session_id="sess_123")
+
+# Set variables
+variables.set("current_task_id", "task_456")
+variables.set("user_preference", {"theme": "dark"})
+variables.set("retry_count", 3)
+
+# Get variables
+task_id = variables.get("current_task_id")       # "task_456"
+missing = variables.get("unknown", "default")    # "default"
+
+# Delete variable
+variables.delete("retry_count")
+
+# List all keys
+keys = variables.keys()  # ["current_task_id", "user_preference"]
+
+# Flatten to string dict
+flat = variables.to_flat_dict()  # All values as strings
+```
+
+### ExecutionContext
+
+Complete context for BAML function injection:
+
+```python
+@dataclass
+class ExecutionContext:
+    session: SessionContext
+    history: ConversationHistory
+    variables: ContextVariables
+    current_intent: Optional[str]
+    current_entities: Optional[dict]
+```
+
+**Usage:**
+```python
+context = await provider.get_execution_context("sess_123")
+
+# Convert to conversation context for BAML
+conv_context = context.to_conversation_context()
+# Returns:
+# {
+#     "session_id": "sess_123",
+#     "user_id": "alice",
+#     "recent_turns": [...],
+#     "variables": {...},
+#     "history_summary": "...",
+#     "turn_count": 5
+# }
+```
+
+## Storage Backends
+
+### InMemoryContextProvider
+
+For development and testing:
+
+```python
+from src.context_primitives.provider import InMemoryContextProvider, ContextConfig
+
+config = ContextConfig(
+    max_history_turns=20,
+    ttl_seconds=3600  # 1 hour
+)
+provider = InMemoryContextProvider(config)
+
+# Basic operations
+session = await provider.create_session("sess_123")
+await provider.add_turn("sess_123", turn)
+await provider.set_variable("sess_123", "key", "value")
+context = await provider.get_execution_context("sess_123")
+
+# Session management
+exists = await provider.session_exists("sess_123")  # True
+await provider.touch_session("sess_123")            # Update activity
+await provider.delete_session("sess_123")           # Remove session
+
+# Bulk operations
+count = provider.session_count()
+await provider.clear_all()
+```
+
+### ContextBackend Options
+
+```python
+from src.context_primitives.provider import ContextBackend
+
+class ContextBackend(Enum):
+    IN_MEMORY = "in_memory"    # Development/testing only
+    REDIS = "redis"            # Hot session storage with TTL
+    POSTGRESQL = "postgresql"  # Persistent history storage
+    DYNAMODB = "dynamodb"      # Serverless deployments
+    HYBRID = "hybrid"          # Redis + PostgreSQL combination
+```
+
+## BAML Integration
+
+### BAML Type Definitions
+
+The context primitives are defined in `baml_src/context_primitives.baml`:
+
+```baml
+// Session context
+class SessionContext {
+  session_id string @description("Unique session identifier")
+  user_id string? @description("Optional user identifier")
+  created_at string @description("ISO 8601 timestamp")
+  last_activity string @description("Last interaction timestamp")
+  metadata map<string, string>?
+  ttl_seconds int?
+  is_active bool
+}
+
+// Conversation history
+class ContextConversationHistory {
+  session_id string
+  turns ContextConversationTurn[]
+  max_turns int
+  total_turns int
+  summary string?
+  token_count int?
+}
+
+// Full execution context
+class FullExecutionContext {
+  session SessionContext
+  history ContextConversationHistory
+  variables ContextVariables
+  current_intent string?
+  current_entities map<string, string>?
+}
+```
+
+### Using Context in BAML Functions
+
+```baml
+function ProcessUserInput(
+  user_input: string,
+  conversation_context: SessionConversationContext?
+) -> IntentResult {
+  client CustomSonnet4
+  prompt #"
+    {% if conversation_context %}
+    CONVERSATION CONTEXT:
+    Session: {{ conversation_context.session_id }}
+    Previous turns: {{ conversation_context.turn_count }}
+
+    {% if conversation_context.history_summary %}
+    Summary: {{ conversation_context.history_summary }}
+    {% endif %}
+
+    Recent conversation:
+    {% for turn in conversation_context.recent_turns %}
+    User: {{ turn.user_input }}
+    Assistant: {{ turn.assistant_response }}
+    {% endfor %}
+
+    Context variables:
+    {{ conversation_context.variables }}
+    {% endif %}
+
+    USER INPUT: {{ user_input }}
+
+    Extract the user's intent and any relevant entities.
+    {{ ctx.output_format }}
+  "#
+}
+```
+
+### Summarization Functions
+
+```baml
+// Summarize conversation for context window management
+function SummarizeConversation(
+  turns: ContextConversationTurn[],
+  existing_summary: string?,
+  max_length: int?
+) -> ConversationSummary {
+  client CustomSonnet4
+  prompt #"
+    Create a concise summary of the conversation turns...
+  "#
+}
+
+// Score turns for importance-based retention
+function ScoreTurnImportance(
+  turns: ContextConversationTurn[],
+  current_context: string?,
+  important_entities: string[]?
+) -> TurnImportance[] {
+  client CustomSonnet4
+  prompt #"
+    Evaluate conversation turns for importance...
+  "#
+}
+```
+
+## Python Dataclass Serialization
+
+All types support serialization to/from Python dataclasses:
+
+```python
+from dataclasses import asdict
+
+# To dictionary
+session_dict = asdict(session)
+turn_dict = turn.to_dict()
+history_dict = history.to_dict()
+
+# From dictionary
+session = SessionContext(**session_dict)
+turn = ConversationTurn.from_dict(turn_dict)
+history = ConversationHistory.from_dict(history_dict)
+
+# JSON serialization
+import json
+
+json_str = json.dumps(turn.to_dict(), default=str)
+restored = ConversationTurn.from_dict(json.loads(json_str))
+```
+
+## Configuration
+
+### ContextConfig
+
+```python
+@dataclass
+class ContextConfig:
+    max_history_turns: int = 20        # Window size
+    summarize_after: int = 10          # When to summarize
+    token_limit: int = 4000            # Max context tokens
+    backend: ContextBackend = ContextBackend.IN_MEMORY
+    ttl_seconds: Optional[int] = 3600  # Session TTL
+```
+
+### BAML Configuration Types
+
+```baml
+enum HistoryTruncationStrategy {
+  SLIDING_WINDOW     // Keep last N turns
+  TOKEN_BASED        // Keep until token limit
+  IMPORTANCE_BASED   // Score and keep important
+  SUMMARIZE          // Summarize before discard
+  HYBRID             // Combine strategies
+}
+
+class TruncationConfig {
+  strategy HistoryTruncationStrategy
+  max_turns int
+  max_tokens int
+  importance_threshold float
+  summarization_prompt string?
+}
+```
+
+## Best Practices
+
+1. **Session Management**
+   - Always set TTL for production sessions
+   - Use meaningful session IDs (UUIDs recommended)
+   - Store user preferences in metadata
+
+2. **History Management**
+   - Set appropriate window size for your use case
+   - Enable summarization for long conversations
+   - Use importance-based truncation for complex dialogues
+
+3. **Variable Storage**
+   - Use consistent naming conventions
+   - Store only essential context
+   - Clean up stale variables
+
+4. **Performance**
+   - Use Redis for production hot storage
+   - Archive to PostgreSQL for persistence
+   - Consider HYBRID backend for best of both
+
+## Related Documentation
+
+- [Phase 7 Implementation Plan](../PHASE7_CONTEXT_PRIMITIVES_PLAN.md)
+- [BAML Type Definitions](../../baml_src/context_primitives.baml)
+- [Provider Implementation](../../src/context_primitives/provider.py)
+- [Unit Tests](../../tests/test_context_primitives/)


### PR DESCRIPTION
## Summary
- Fixed BAML client generation errors across 25 BAML files
- Added comprehensive documentation for context primitives
- All 83 context primitives tests pass

## Changes

### BAML Syntax Fixes
- **Client references**: Changed `client GPT4` to `client CustomSonnet4` in context_primitives.baml
- **Function parameter syntax**: Fixed missing colons in function parameters across 25 files (e.g., `input LiveRegionInput` → `input: LiveRegionInput`)
- **Jinja template syntax**: Fixed `{% elsif %}` to `{% elif %}` in accessibility_analysis.baml, disability_evaluation.baml
- **Reserved word field names**: 
  - `protocol` → `comm_protocol` in agent_identity.baml, agent_card.baml
  - `fixed` → `is_fixed` in proposal_evaluation.baml

### Duplicate Type Resolution
Resolved 20+ duplicate type definitions with domain-specific prefixes:
| Original | Renamed | File |
|----------|---------|------|
| ContentType | ARIAContentType | aria_live_regions.baml |
| ExecutionContext | CompositionExecutionContext | composition_execution.baml |
| RiskLevel | NegotiationRiskLevel | negotiation_protocol.baml |
| ChangeType | ProposalChangeType | proposal_evaluation.baml |
| TrustLevel | SecurityTrustLevel | security_context.baml |
| ExecutionStatus | ContractExecutionStatus | contract_net.baml |
| ViolationSeverity | ValidationViolationSeverity | accessibility_validation.baml |
| And many more... | | |

### Documentation
- Added `docs/context_primitives/USER_GUIDE.md` with:
  - Quick start guide
  - Core type documentation (SessionContext, ConversationTurn, ConversationHistory, etc.)
  - Storage backend options
  - BAML integration examples
  - Python dataclass serialization
  - Best practices

## Test plan
- [x] BAML client generates successfully (`uv run baml-cli generate`)
- [x] All 83 context primitives tests pass (`uv run pytest tests/test_context_primitives/ -v`)
- [x] No duplicate type errors in BAML generation

## Issue
Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)